### PR TITLE
feat: Add social media to contacts and fix duplicate widget entry

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,6 @@
             android:exported="true"
             android:theme="@style/Theme.QrLockscreen">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/data/QrConfig.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/data/QrConfig.kt
@@ -2,6 +2,12 @@ package com.hereliesaz.qrlockscreen.data
 
 import kotlinx.serialization.Serializable
 
+enum class QrDataType {
+    Links,
+    Contact,
+    SocialMedia
+}
+
 @Serializable
 sealed class QrData {
     @Serializable
@@ -15,7 +21,6 @@ sealed class QrData {
         val organization: String = "",
         val website: String = "",
         val socialLinks: List<SocialLink> = emptyList()
-
     ) : QrData()
 
     @Serializable

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/widget/QrGenerator.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/widget/QrGenerator.kt
@@ -16,9 +16,9 @@ object QrGenerator {
 
     fun generate(config: QrConfig): Bitmap? {
         val dataString = when (config.data) {
-            is QrData.Links -> config.data.links.joinToString("\n")
+            is QrData.Links -> config.data.links.filter { it.isNotBlank() }.joinToString("\n")
             is QrData.Contact -> createVCard(config.data)
-            is QrData.SocialMedia -> config.data.links.joinToString("\n") { "${it.platform}: ${it.url}" }
+            is QrData.SocialMedia -> config.data.links.filter { it.url.isNotBlank() }.joinToString("\n") { "${it.platform}: ${it.url}" }
         }
 
         if (dataString.isBlank()) return null
@@ -45,7 +45,7 @@ object QrGenerator {
     }
 
     private fun createVCard(contact: QrData.Contact): String {
-        val socialLinks = contact.socialLinks.joinToString("\n") {
+        val socialLinks = contact.socialLinks.filter { it.url.isNotBlank() }.joinToString("\n") {
             "X-SOCIALPROFILE;type=${it.platform}:${it.url}"
         }
         return """
@@ -57,7 +57,6 @@ object QrGenerator {
             URL:${contact.website}
             EMAIL:${contact.email}
             $socialLinks
-
             END:VCARD
         """.trimIndent()
     }


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Adds social media links to the contact card.** The contact data model and UI have been updated to allow for the inclusion of social media profiles within a contact's vCard.
2.  **Fixes a bug that caused duplicate entries in the widget picker.** The `LAUNCHER` intent filter has been removed from the configuration activity to resolve this issue.

## Summary by Sourcery

Enable rich social media sharing in QR widgets, overhaul the configuration UI with a type selector, color pickers, and live preview, update the data model and generator to support new payload types, fix duplicate widget registrations, and refresh project documentation.

New Features:
- Introduce a SocialMedia data type and allow users to add social media links to contact QR codes
- Add a data type selector, dynamic forms (links, contacts, social media), color picker dialogs, and live QR preview in the configuration screen
- Enhance QrGenerator to produce vCards with embedded social profiles and support the new data types

Bug Fixes:
- Prevent duplicate widget entries by removing the LAUNCHER intent filter from the configuration activity

Enhancements:
- Migrate QrConfig to use a sealed QrData model with typed payloads and integer color values
- Rename project namespace and package identifiers for consistent lowercase naming
- Revamp README with comprehensive installation, usage instructions, and documentation

Build:
- Add color picker library dependency for Compose