### PR TITLE
feat: Unify background colors for loading screen and system bars

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,9 @@ dependencies {
     // Color Picker
     implementation("com.godaddy.android.colorpicker:compose-color-picker:0.7.0")
 
+    // Material Kolor for palette generation
+    implementation("com.materialkolor:material-kolor:3.0.0")
+
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,9 +14,18 @@
         tools:targetApi="31">
 
         <activity
+            android:name=".ui.LockscreenActivity"
+            android:exported="false"
+            android:theme="@style/Theme.QrLockscreen" />
+
+        <activity
             android:name=".ui.ConfigActivity"
             android:exported="true"
             android:theme="@style/Theme.QrLockscreen">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,13 @@
 
         <activity
             android:name=".ui.LockscreenActivity"
-            android:exported="false"
-            android:theme="@style/Theme.QrLockscreen" />
+            android:exported="true"
+            android:theme="@style/Theme.QrLockscreen">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ui.ConfigActivity"

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/data/QrConfig.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/data/QrConfig.kt
@@ -2,6 +2,9 @@ package com.hereliesaz.qrlockscreen.data
 
 import kotlinx.serialization.Serializable
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
 enum class QrDataType {
     Links,
     Contact,
@@ -31,16 +34,34 @@ sealed class QrData {
 data class SocialLink(val platform: String, val url: String)
 
 @Serializable
+enum class BackgroundType {
+    SOLID,
+    GRADIENT
+}
+
+@Serializable
+enum class ForegroundType {
+    SOLID,
+    GRADIENT
+}
+
+@Serializable
 data class QrConfig(
     val data: QrData = QrData.Links(),
     val shape: QrShape = QrShape.Square,
+    val foregroundType: ForegroundType = ForegroundType.SOLID,
     val foregroundColor: Int = 0xFF000000.toInt(),
+    val foregroundGradientColors: List<Int> = listOf(Color.Black.toArgb(), Color.Blue.toArgb()),
+    val backgroundType: BackgroundType = BackgroundType.SOLID,
     val backgroundColor: Int = 0xFFFFFFFF.toInt(),
+    val backgroundGradientColors: List<Int> = listOf(Color.White.toArgb(), Color.Black.toArgb()),
+    val backgroundGradientAngle: Float = 0f,
 )
 
 @Serializable
 enum class QrShape {
     Square,
     Circle,
-    RoundSquare
+    RoundSquare,
+    Diamond
 }

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/ui/ConfigActivity.kt
@@ -89,13 +89,22 @@ fun ConfigScreen(appWidgetId: Int, qrWidget: QrWidget, onConfigComplete: () -> U
     }
 
     if (config == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            contentAlignment = Alignment.Center
+        ) {
             CircularProgressIndicator()
         }
         return
     }
 
-    Surface(modifier = Modifier.fillMaxSize()) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .safeDrawingPadding()
+    ) {
         AnimatedVisibility(
             visible = config != null,
             enter = fadeIn(animationSpec = tween(durationMillis = 300)) + slideInVertically(
@@ -113,123 +122,141 @@ fun ConfigScreen(appWidgetId: Int, qrWidget: QrWidget, onConfigComplete: () -> U
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Text("Configure QR Code", style = MaterialTheme.typography.headlineSmall)
+                Text(
+                    "Configure QR Code",
+                    style = MaterialTheme.typography.headlineLarge,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
 
                 var selectedDataType by remember {
-                mutableStateOf(
-                    when (config!!.data) {
-                        is QrData.Links -> QrDataType.Links
-                        is QrData.Contact -> QrDataType.Contact
-                        is QrData.SocialMedia -> QrDataType.SocialMedia
-                    }
-                )
-            }
-
-            DataTypeSelector(
-                selectedType = selectedDataType,
-                onTypeSelected = { newType ->
-                    selectedDataType = newType
-                    val newData = when (newType) {
-                        QrDataType.Links -> QrData.Links()
-                        QrDataType.Contact -> QrData.Contact()
-                        QrDataType.SocialMedia -> QrData.SocialMedia()
-                    }
-                    config = config!!.copy(data = newData)
-                }
-            )
-
-            when (val data = config!!.data) {
-                is QrData.Links -> {
-                    LinksForm(
-                        links = data,
-                        onLinksChange = { newLinks ->
-                            config = config!!.copy(data = newLinks)
+                    mutableStateOf(
+                        when (config!!.data) {
+                            is QrData.Links -> QrDataType.Links
+                            is QrData.Contact -> QrDataType.Contact
+                            is QrData.SocialMedia -> QrDataType.SocialMedia
                         }
                     )
                 }
-                is QrData.Contact -> {
-                    ContactForm(
-                        contact = data,
-                        onContactChange = { newContact ->
-                            config = config!!.copy(data = newContact)
-                        }
-                    )
-                }
-                is QrData.SocialMedia -> {
-                    SocialMediaForm(
-                        socialMedia = data,
-                        onSocialMediaChange = { newSocialMedia ->
-                            config = config!!.copy(data = newSocialMedia)
-                        }
-                    )
-                }
-            }
 
-            var shapeExpanded by remember { mutableStateOf(false) }
-            ExposedDropdownMenuBox(
-                expanded = shapeExpanded,
-                onExpandedChange = { shapeExpanded = !shapeExpanded }
-            ) {
-                OutlinedTextField(
-                    readOnly = true,
-                    value = config!!.shape.name,
-                    onValueChange = {},
-                    label = { Text("Shape") },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = shapeExpanded) },
-                    modifier = Modifier
-                        .menuAnchor()
-                        .fillMaxWidth()
-                )
-                ExposedDropdownMenu(
-                    expanded = shapeExpanded,
-                    onDismissRequest = { shapeExpanded = false }
-                ) {
-                    QrShape.values().forEach { selectionOption ->
-                        DropdownMenuItem(
-                            text = { Text(selectionOption.name) },
-                            onClick = {
-                                config = config!!.copy(shape = selectionOption)
-                                shapeExpanded = false
+                // Data Section
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text("Data", style = MaterialTheme.typography.titleLarge)
+                        DataTypeSelector(
+                            selectedType = selectedDataType,
+                            onTypeSelected = { newType ->
+                                selectedDataType = newType
+                                val newData = when (newType) {
+                                    QrDataType.Links -> QrData.Links()
+                                    QrDataType.Contact -> QrData.Contact()
+                                    QrDataType.SocialMedia -> QrData.SocialMedia()
+                                }
+                                config = config!!.copy(data = newData)
                             }
+                        )
+
+                        when (val data = config!!.data) {
+                            is QrData.Links -> LinksForm(links = data) { newLinks ->
+                                config = config!!.copy(data = newLinks)
+                            }
+                            is QrData.Contact -> ContactForm(contact = data) { newContact ->
+                                config = config!!.copy(data = newContact)
+                            }
+                            is QrData.SocialMedia -> SocialMediaForm(socialMedia = data) { newSocialMedia ->
+                                config = config!!.copy(data = newSocialMedia)
+                            }
+                        }
+                    }
+                }
+
+                // Appearance Section
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text("Appearance", style = MaterialTheme.typography.titleLarge)
+
+                        var shapeExpanded by remember { mutableStateOf(false) }
+                        ExposedDropdownMenuBox(
+                            expanded = shapeExpanded,
+                            onExpandedChange = { shapeExpanded = !shapeExpanded }
+                        ) {
+                            OutlinedTextField(
+                                readOnly = true,
+                                value = config!!.shape.name,
+                                onValueChange = {},
+                                label = { Text("Shape") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = shapeExpanded) },
+                                modifier = Modifier
+                                    .menuAnchor()
+                                    .fillMaxWidth()
+                            )
+                            ExposedDropdownMenu(
+                                expanded = shapeExpanded,
+                                onDismissRequest = { shapeExpanded = false }
+                            ) {
+                                QrShape.values().forEach { selectionOption ->
+                                    DropdownMenuItem(
+                                        text = { Text(selectionOption.name) },
+                                        onClick = {
+                                            config = config!!.copy(shape = selectionOption)
+                                            shapeExpanded = false
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        ColorPickerField(
+                            label = "Foreground Color",
+                            color = config!!.foregroundColor,
+                            onClick = { showForegroundColorPicker = true }
+                        )
+
+                        ColorPickerField(
+                            label = "Background Color",
+                            color = config!!.backgroundColor,
+                            onClick = { showBackgroundColorPicker = true }
                         )
                     }
                 }
-            }
 
-            ColorPickerField(
-                label = "Foreground Color",
-                color = config!!.foregroundColor,
-                onClick = { showForegroundColorPicker = true }
-            )
-
-            ColorPickerField(
-                label = "Background Color",
-                color = config!!.backgroundColor,
-                onClick = { showBackgroundColorPicker = true }
-            )
-
-            Button(
-                onClick = {
-                    scope.launch {
-                        dataStore.saveConfig(appWidgetId, config!!)
-                        val glanceId =
-                            GlanceAppWidgetManager(context).getGlanceIdBy(appWidgetId)
-                        qrWidget.update(context, glanceId)
-                        onConfigComplete()
+                // Preview Section
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        QrCodePreview(config = config!!)
                     }
-                },
-                enabled = when (val data = config!!.data) {
-                    is QrData.Links -> data.links.any { it.isNotBlank() }
-                    is QrData.Contact -> data.name.isNotBlank()
-                    is QrData.SocialMedia -> data.links.any { it.url.isNotBlank() }
                 }
-            ) {
-                Text("Create Widget")
-            }
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-            QrCodePreview(config = config!!)
+                Button(
+                    onClick = {
+                        scope.launch {
+                            dataStore.saveConfig(appWidgetId, config!!)
+                            val glanceId =
+                                GlanceAppWidgetManager(context).getGlanceIdBy(appWidgetId)
+                            qrWidget.update(context, glanceId)
+                            onConfigComplete()
+                        }
+                    },
+                    enabled = when (val data = config!!.data) {
+                        is QrData.Links -> data.links.any { it.isNotBlank() }
+                        is QrData.Contact -> data.name.isNotBlank()
+                        is QrData.SocialMedia -> data.links.any { it.url.isNotBlank() }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Create Widget")
+                }
         }
         }
     }

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/ui/LockscreenActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/ui/LockscreenActivity.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.qrlockscreen.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+import com.hereliesaz.qrlockscreen.ui.theme.QrLockscreenTheme
+
+class LockscreenActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            QrLockscreenTheme {
+                Text("This is the lock screen activity.")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/ui/theme/Theme.kt
@@ -57,8 +57,10 @@ fun QrLockscreenTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            window.statusBarColor = colorScheme.surface.toArgb()
+            window.navigationBarColor = colorScheme.surface.toArgb()
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/ui/theme/Theme.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -58,11 +57,8 @@ fun QrLockscreenTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.surface.toArgb()
-            window.navigationBarColor = colorScheme.surface.toArgb()
-
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/qrlockscreen/widget/shape/DiamondShapeFunction.kt
+++ b/app/src/main/java/com/hereliesaz/qrlockscreen/widget/shape/DiamondShapeFunction.kt
@@ -1,0 +1,28 @@
+package com.hereliesaz.qrlockscreen.widget.shape
+
+import qrcode.raw.QRCodeProcessor
+import qrcode.render.QRCodeGraphics
+import qrcode.shape.DefaultShapeFunction
+import java.awt.Polygon
+
+/**
+ * A custom shape function that draws diamonds instead of squares.
+ */
+class DiamondShapeFunction(
+    squareSize: Int = QRCodeProcessor.DEFAULT_CELL_SIZE,
+    innerSpace: Int = 1,
+) : DefaultShapeFunction(squareSize, innerSpace) {
+    override fun fillRect(x: Int, y: Int, width: Int, height: Int, color: Int, canvas: QRCodeGraphics) {
+        canvas.directDraw { graphics -> // JVM only for now
+            val diamond = Polygon()
+            diamond.addPoint(x + width / 2, y) // Top
+            diamond.addPoint(x + width, y + height / 2) // Right
+            diamond.addPoint(x + width / 2, y + height) // Bottom
+            diamond.addPoint(x, y + height / 2) // Left
+
+            val (r, g, b, a) = qrcode.color.Colors.getRGBA(color)
+            graphics.paint = java.awt.Color(r, g, b, a)
+            graphics.fill(diamond)
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Unify surface background colors for loading indicators and system bars, reorganize the widget configuration screen into clear sections, and introduce a placeholder lock screen activity.

New Features:
- Add a LockscreenActivity stub for the lock screen interface

Enhancements:
- Use the surface color as the background for the loading state and apply it to status and navigation bars
- Restructure the ConfigScreen into Data, Appearance, and Preview sections using cards, updated typography, and safe drawing padding
- Update typography, spacing, and button layout in the configuration UI