### PR TITLE
fix(compose): Use correct drawable resource for app icon

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -173,8 +173,7 @@ fun ConfigScreen(appWidgetId: Int, qrWidget: QrWidget, onConfigComplete: () -> U
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Image(
-                painter = painterResource(id = com.hereliesaz.qard.R.drawable.ic_launcher),
-
+                painter = painterResource(id = R.mipmap.ic_launcher_foreground),
                 contentDescription = "App Icon",
                 modifier = Modifier.size(64.dp)
             )


### PR DESCRIPTION
The `painterResource` function in Jetpack Compose does not support adaptive icons directly. The previous code was using `R.drawable.ic_launcher`, which is an adaptive icon XML, causing an `IllegalArgumentException` at runtime.

This commit fixes the crash by changing the resource to `R.mipmap.ic_launcher_foreground`, which is a renderable asset (a WEBP file) and is the appropriate foreground layer of the adaptive icon.