### PR TITLE
Refactor(widget): Simplify config save logic to prevent race conditions

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -117,9 +117,6 @@ fun ConfigScreen(appWidgetId: Int, qrWidget: QrWidget, onConfigComplete: () -> U
 
     val updateConfig = { newConfig: QrConfig ->
         config = newConfig
-        scope.launch {
-            dataStore.saveConfig(appWidgetId, newConfig)
-        }
     }
     var showForegroundColorPicker by remember { mutableStateOf(false) }
     var showBackgroundColorPicker by remember { mutableStateOf(false) }
@@ -462,6 +459,8 @@ fun ConfigScreen(appWidgetId: Int, qrWidget: QrWidget, onConfigComplete: () -> U
                 Button(
                     onClick = {
                         scope.launch {
+                dataStore.saveConfig(appWidgetId, currentConfig)
+
                             val currentSaved = dataStore.getSavedConfigs().first()
                             val newSaved = (currentSaved + currentConfig).distinct()
                             dataStore.saveConfigs(newSaved)


### PR DESCRIPTION
The previous implementation saved the widget configuration to DataStore on every UI change in the configuration activity. This could lead to a race condition where an intermediate or incomplete configuration was the last one to be persisted, causing the widget to be created with empty data.

This change simplifies the logic by removing the save operation from the `updateConfig` lambda. The configuration is now only saved when the user explicitly clicks the "Create Widget" button. This ensures that only the final, complete configuration is persisted, making the process more robust and predictable.

## Summary by Sourcery

Refactor config persistence in ConfigActivity to avoid intermediate saves and only persist the completed configuration when the user clicks "Create Widget"

Bug Fixes:
- Prevent race condition by ensuring only the final widget configuration is saved

Enhancements:
- Removed per-change config saves and consolidated persistence to the "Create Widget" button action