### PR TITLE
Fix version-auto-increment build: import java.util.Properties, add ve…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,45 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.kotlin.compose)
-
-
 }
+
+// --- Versioning -----------------------------------------------------------
+// versionName is composed from version.properties (major/minor/patch); the
+// build number (versionBuild) is auto-incremented on release builds.
+val versionPropsFile = file("version.properties")
+val versionProps = Properties().apply {
+    if (versionPropsFile.exists()) {
+        versionPropsFile.inputStream().use { load(it) }
+    }
+}
+
+val localPropertiesFile = rootProject.file("local.properties")
+val localProperties = Properties().apply {
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
+}
+
+var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
+
+val isReleaseBuild = gradle.startParameter.taskNames.any {
+    it.contains("Release", ignoreCase = true) || it.contains("bundle", ignoreCase = true)
+}
+if (isReleaseBuild) {
+    currentVersionCode += 1
+    versionProps.setProperty("versionBuild", currentVersionCode.toString())
+    versionPropsFile.outputStream().use {
+        versionProps.store(it, "Auto-incremented by release build")
+    }
+}
+
+val verMajor = versionProps.getProperty("versionMajor", "1")
+val verMinor = versionProps.getProperty("versionMinor", "0")
+val verPatch = versionProps.getProperty("versionPatch", "0")
 
 android {
     namespace = "com.hereliesaz.qard"
@@ -15,8 +49,8 @@ android {
         applicationId = "com.hereliesaz.qard"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7
-        versionName = "2.0.2"
+        versionCode = currentVersionCode
+        versionName = "$verMajor.$verMinor.$verPatch"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,0 +1,4 @@
+versionMajor=2
+versionMinor=0
+versionPatch=2
+versionBuild=7


### PR DESCRIPTION
…rsion.properties

The version-auto-increment block uses java.util.Properties, which is not auto-imported in Gradle Kotlin DSL scripts. Add the explicit import (above the plugins block) so Properties/load/store/getProperty/setProperty resolve, wire versionCode/versionName to version.properties (major/minor/patch + auto-bumped versionBuild on release builds), and seed version.properties to the current 2.0.2 / build 7.

## Summary by Sourcery

Wire Android app versioning to a new version.properties file and enable automatic increment of the build number on release builds.

New Features:
- Introduce property-based versioning that derives versionName and versionCode from version.properties.

Enhancements:
- Add Gradle Kotlin DSL logic to load and persist version information, including auto-incrementing the build number for release and bundle tasks.

Build:
- Import java.util.Properties and configure the Android Gradle module to read/write version metadata from version.properties instead of hardcoding versionCode and versionName.