### PR TITLE
Fix duplicated version block breaking the build on main

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,15 +10,15 @@ plugins {
 // --- Versioning -----------------------------------------------------------
 // versionName is composed from version.properties (major/minor/patch); the
 // build number (versionBuild) is auto-incremented on release builds.
-val versionPropsFile = file("version.properties")
+val versionPropsFile = rootProject.file("version.properties")
 val versionProps = Properties().apply {
     if (versionPropsFile.exists()) {
         versionPropsFile.inputStream().use { load(it) }
     }
 }
 
-val localPropertiesFile = rootProject.file("local.properties")
 val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
     if (localPropertiesFile.exists()) {
         localPropertiesFile.inputStream().use { load(it) }
     }
@@ -26,36 +26,10 @@ val localProperties = Properties().apply {
 
 var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
 
+// Automatically increment versionCode for release builds.
 val isReleaseBuild = gradle.startParameter.taskNames.any {
     it.contains("Release", ignoreCase = true) || it.contains("bundle", ignoreCase = true)
 }
-if (isReleaseBuild) {
-    currentVersionCode += 1
-    versionProps.setProperty("versionBuild", currentVersionCode.toString())
-    versionPropsFile.outputStream().use {
-        versionProps.store(it, "Auto-incremented by release build")
-    }
-}
-// Load version properties
-val versionPropsFile = project.rootProject.file("version.properties")
-val versionProps = Properties().apply {
-    if (versionPropsFile.exists()) {
-        versionPropsFile.inputStream().use { load(it) }
-    }
-}
-
-// Load local properties
-val localProperties = Properties().apply {
-    val localPropertiesFile = project.rootProject.file("local.properties")
-    if (localPropertiesFile.exists()) {
-        localPropertiesFile.inputStream().use { load(it) }
-    }
-}
-
-var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
-
-// Automatically increment versionCode for release builds
-val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
 if (isReleaseBuild) {
     currentVersionCode++
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
@@ -67,7 +41,6 @@ if (isReleaseBuild) {
 val verMajor = versionProps.getProperty("versionMajor", "1")
 val verMinor = versionProps.getProperty("versionMinor", "0")
 val verPatch = versionProps.getProperty("versionPatch", "0")
-val verBuild = versionProps.getProperty("versionBuild", "1")
 val currentVersionName = "$verMajor.$verMinor.$verPatch"
 
 android {
@@ -79,7 +52,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = currentVersionCode
-        versionName = "$verMajor.$verMinor.$verPatch"
+        versionName = currentVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,0 @@
-versionMajor=2
-versionMinor=0
-versionPatch=2
-versionBuild=7


### PR DESCRIPTION
## Problem

`main` is currently broken: the merge of PR #32 concatenated **two** near-identical version-auto-increment blocks in `app/build.gradle.kts` (one from `main`, one from this branch). That produced duplicate top-level declarations (`versionPropsFile`, `versionProps`, `localProperties`, `currentVersionCode`, `isReleaseBuild`, …) and ~45 *"overload resolution ambiguity"* / unresolved-reference compile errors.

## Fix

- Collapse the two blocks into a **single** version block that reads the root `version.properties` (major/minor/patch) and auto-increments `versionBuild` on release builds.
- Keep `import java.util.Properties` (required — it's not auto-imported in Gradle Kotlin DSL).
- Remove the stale `app/version.properties` (root `version.properties` — 2.0.4 / build 9 — is canonical).
- Retains the debug-signing on the `release` build type so `app-release.apk` is installable.

This restores `main` to a compiling state.

## Verification

- CI `build` on this branch should compile cleanly.
- `./gradlew assembleDebug` / `assembleRelease`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRKfnK7bSkN4F7WL8wbKwt)_

## Summary by Sourcery

Fix Gradle versioning configuration to remove duplicated declarations and restore a successful build on main.

Bug Fixes:
- Resolve duplicated versioning logic in app/build.gradle.kts that caused compilation failures on main.

Enhancements:
- Centralize version and local properties loading using the root project version.properties file and a single versioning block.
- Derive versionName from a composed currentVersionName string based on major, minor, and patch values.

Chores:
- Remove the obsolete app/version.properties file in favor of the canonical root-level version.properties.