### PR TITLE
Address review: goAsync in pin receiver, clearer widget button label

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -934,7 +934,7 @@ fun SaveScreen(
             enabled = hasData,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(if (isStandalone) "Create widget" else "Add to home screen")
+            Text(if (isStandalone) "Create widget" else "Save widget")
         }
         OutlinedButton(
             onClick = onSaveImage,

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrWidgetReceiver.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrWidgetReceiver.kt
@@ -10,8 +10,11 @@ import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.updateAll
 import com.hereliesaz.qard.data.QrDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 
 class QrWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = QrWidget()
@@ -36,13 +39,20 @@ class QrWidgetReceiver : GlanceAppWidgetReceiver() {
         )
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return
 
-        runBlocking {
-            val store = QrDataStore(context)
-            val config = store.takePendingPinConfig() ?: return@runBlocking
-            store.saveConfig(appWidgetId, config)
-            val saved = store.getSavedConfigs().first()
-            store.saveConfigs((saved + config).distinct())
-            QrWidget().updateAll(context)
+        // Do the DataStore I/O off the main thread; goAsync() keeps the receiver
+        // alive until the coroutine finishes so we don't risk an ANR.
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
+                val store = QrDataStore(context)
+                val config = store.takePendingPinConfig() ?: return@launch
+                store.saveConfig(appWidgetId, config)
+                val saved = store.getSavedConfigs().first()
+                store.saveConfigs((saved + config).distinct())
+                QrWidget().updateAll(context)
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 


### PR DESCRIPTION
- QrWidgetReceiver: move the pin-success DataStore I/O off the main thread with goAsync() + Dispatchers.IO instead of runBlocking, avoiding ANR risk.
- SaveScreen: label the widget-config finalize action "Save widget" so it reads distinctly from the standalone "Create widget" pin action.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

## Summary by Sourcery

Move widget pin configuration persistence off the main thread and clarify the widget configuration save button label.

Bug Fixes:
- Avoid potential ANRs in the widget pin flow by performing DataStore I/O asynchronously using goAsync and a background coroutine scope.

Enhancements:
- Update the widget configuration screen’s primary action label to distinguish between standalone widget creation and saving a configured widget.