### PR TITLE
Add AdMob to a play flavor; keep the foss (GitHub) build ad-free

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,8 @@ jobs:
           set +e
           export BUILD_NUMBER=$(git rev-list --count HEAD)
           
-          # Build the APK
-          ./gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache \
+          # Build the ad-free FOSS APK (the artifact published to GitHub Releases).
+          ./gradlew assembleFossDebug -PversionBuild=$BUILD_NUMBER --build-cache \
             -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
             -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
             -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
@@ -188,7 +188,7 @@ jobs:
           fi
           
           # Locate built APK
-          APK_ORIGINAL=$(find app/build/outputs/apk/debug -name "*.apk" | head -n 1)
+          APK_ORIGINAL=$(find app/build/outputs/apk/foss/debug -name "*.apk" | head -n 1)
           
           if [ -z "$APK_ORIGINAL" ]; then
              echo "Error: No APK found to release!"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,21 @@ android {
         }
     }
 
+    // Two distributions: "foss" is the ad-free build the repo's CI compiles and
+    // publishes to GitHub Releases; "play" carries the AdMob banner + interstitial
+    // for the Play Store. Ad SDK, ad code, and the AdMob manifest entries live only
+    // in the play flavor (src/play), so the foss artifact contains no ads at all.
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("foss") {
+            dimension = "distribution"
+            isDefault = true
+        }
+        create("play") {
+            dimension = "distribution"
+        }
+    }
+
     // Release signing config sourced from local.properties (KEYSTORE points to
     // the .jks file; KEYSTORE_SECRET / KEY_SECRET / KEY_ALIAS hold the
     // credentials). Only registered when the keystore file is actually present
@@ -150,6 +165,9 @@ dependencies {
 
     // Menu
     implementation(libs.aznavrail)
+
+    // Google AdMob — play flavor only, so the foss build pulls in no ad SDK.
+    "playImplementation"(libs.play.services.ads)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/foss/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/foss/java/com/hereliesaz/qard/ads/Ads.kt
@@ -21,6 +21,11 @@ fun AdBanner(modifier: Modifier = Modifier) {
     // No ads in the FOSS build — render nothing.
 }
 
+@Composable
+fun PresetsAdBanner(modifier: Modifier = Modifier) {
+    // No ads in the FOSS build — render nothing.
+}
+
 class InterstitialController {
     fun showIfReady(activity: Activity) {
         // No ads in the FOSS build.

--- a/app/src/foss/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/foss/java/com/hereliesaz/qard/ads/Ads.kt
@@ -1,0 +1,32 @@
+package com.hereliesaz.qard.ads
+
+import android.app.Activity
+import android.app.Application
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+/**
+ * Ad-free (FOSS) implementation. Every ad entry point is a no-op so the build the
+ * GitHub repo compiles ships without the AdMob SDK or any ads. The matching `play`
+ * flavor (src/play) provides the real AdMob-backed implementation.
+ */
+
+fun initAds(app: Application) {
+    // No ads in the FOSS build.
+}
+
+@Composable
+fun AdBanner(modifier: Modifier = Modifier) {
+    // No ads in the FOSS build — render nothing.
+}
+
+class InterstitialController {
+    fun showIfReady(activity: Activity) {
+        // No ads in the FOSS build.
+    }
+}
+
+@Composable
+fun rememberInterstitialController(): InterstitialController =
+    remember { InterstitialController() }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:maxSdkVersion="28" />
 
     <application
+        android:name=".QaRdApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
+++ b/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
@@ -1,0 +1,15 @@
+package com.hereliesaz.qard
+
+import android.app.Application
+import com.hereliesaz.qard.ads.initAds
+
+/**
+ * Application entry point. [initAds] is flavor-specific: it initializes the AdMob
+ * SDK in the `play` build and is a no-op in the ad-free `foss` build.
+ */
+class QaRdApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        initAds(this)
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -102,6 +102,7 @@ import com.hereliesaz.qard.data.QrDataType
 import com.hereliesaz.qard.data.QrShape
 import com.hereliesaz.qard.data.SocialLink
 import com.hereliesaz.qard.ads.AdBanner
+import com.hereliesaz.qard.ads.PresetsAdBanner
 import com.hereliesaz.qard.ads.rememberInterstitialController
 import com.hereliesaz.qard.ui.theme.LogoPink
 import com.hereliesaz.qard.ui.theme.QaRdTheme
@@ -853,6 +854,8 @@ fun PresetsScreen(
             "Tap a preset to apply its colours and shape to your data.",
             style = MaterialTheme.typography.bodyMedium
         )
+        // Presets-screen banner ("qard-presets-ad"); no-op in the foss build.
+        PresetsAdBanner()
         LazyVerticalGrid(
             columns = GridCells.Adaptive(minSize = 120.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -88,6 +88,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.godaddy.android.colorpicker.ClassicColorPicker
 import com.godaddy.android.colorpicker.HsvColor
@@ -100,6 +101,8 @@ import com.hereliesaz.qard.data.QrDataStore
 import com.hereliesaz.qard.data.QrDataType
 import com.hereliesaz.qard.data.QrShape
 import com.hereliesaz.qard.data.SocialLink
+import com.hereliesaz.qard.ads.AdBanner
+import com.hereliesaz.qard.ads.rememberInterstitialController
 import com.hereliesaz.qard.ui.theme.LogoPink
 import com.hereliesaz.qard.ui.theme.QaRdTheme
 import com.hereliesaz.qard.widget.QrGenerator
@@ -430,6 +433,17 @@ fun ConfigScreen(
 
     val navController = rememberNavController()
 
+    // Show a full-screen interstitial when the user opens the Save rail item.
+    // (No-op in the ad-free foss build.)
+    val activity = context as? Activity
+    val interstitial = rememberInterstitialController()
+    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+    LaunchedEffect(currentRoute) {
+        if (currentRoute == "save") {
+            activity?.let { interstitial.showIfReady(it) }
+        }
+    }
+
     AzHostActivityLayout(navController = navController) {
         // Selected rail item highlight — logo pink so it stands out on the dark rail.
         azTheme(activeColor = LogoPink)
@@ -441,7 +455,9 @@ fun ConfigScreen(
         azRailItem(id = "save", text = "Save", route = "save", content = Icons.Default.Save)
 
         onscreen {
-            AzNavHost(startDestination = "data") {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.weight(1f)) {
+                    AzNavHost(startDestination = "data") {
                 composable("load") {
                     LoadScreen(dataStore = dataStore, updateConfig = loadSavedConfig)
                 }
@@ -479,6 +495,10 @@ fun ConfigScreen(
                         onCreateWidget = { if (isStandalone) pinCurrentAsWidget() else finalizeWidget() }
                     )
                 }
+            }
+                }
+                // Banner pinned to the bottom of every editor screen (play flavor only).
+                AdBanner()
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -435,7 +435,15 @@ fun ConfigScreen(
 
     // Show a full-screen interstitial when the user opens the Save rail item.
     // (No-op in the ad-free foss build.)
-    val activity = context as? Activity
+    // Unwrap any ContextWrapper (e.g. Compose's ContextThemeWrapper) to reach the Activity.
+    val activity = remember(context) {
+        var ctx: Context = context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is Activity) break
+            ctx = ctx.baseContext
+        }
+        ctx as? Activity
+    }
     val interstitial = rememberInterstitialController()
     val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
     LaunchedEffect(currentRoute) {

--- a/app/src/main/java/com/hereliesaz/qard/ui/DetailActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/DetailActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.hereliesaz.qard.ads.AdBanner
 import com.hereliesaz.qard.data.QrConfig
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.data.QrDataStore
@@ -139,7 +140,8 @@ fun QrCodeDetailScreen(config: QrConfig, onBack: () -> Unit) {
                     }
                 }
             )
-        }
+        },
+        bottomBar = { AdBanner() }
     ) { padding ->
         Column(
             modifier = Modifier

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- AdMob needs network access; merged into the play flavor only. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <!-- Google's official TEST AdMob app id. Replace with your real app id
+             (ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY) before publishing. -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+    </application>
+</manifest>

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -5,10 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
-        <!-- Google's official TEST AdMob app id. Replace with your real app id
-             (ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY) before publishing. -->
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713" />
+            android:value="ca-app-pub-7304740804770627~8885554152" />
     </application>
 </manifest>

--- a/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
@@ -3,6 +3,8 @@ package com.hereliesaz.qard.ads
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -19,10 +21,10 @@ import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 
-// Google's official TEST ad unit IDs. Replace with your real AdMob unit IDs before
-// publishing (the AdMob app id lives in src/play/AndroidManifest.xml). Using the
-// test IDs in development is required by AdMob policy to avoid invalid traffic.
-private const val BANNER_UNIT_ID = "ca-app-pub-3940256099942544/6300978111"
+// Real AdMob unit IDs (the AdMob app id lives in src/play/AndroidManifest.xml).
+// BANNER_UNIT_ID is the "qard-bottom-banner" unit. INTERSTITIAL_UNIT_ID is still
+// Google's official TEST unit id — replace it once a real interstitial unit exists.
+private const val BANNER_UNIT_ID = "ca-app-pub-7304740804770627/1570507628"
 private const val INTERSTITIAL_UNIT_ID = "ca-app-pub-3940256099942544/1033173712"
 
 fun initAds(app: Application) {
@@ -40,24 +42,31 @@ fun AdBanner(modifier: Modifier = Modifier) {
                 adUnitId = BANNER_UNIT_ID
                 loadAd(AdRequest.Builder().build())
             }
-        }
+        },
+        // Release the AdView when it leaves composition to avoid a memory leak.
+        onRelease = { adView -> adView.destroy() }
     )
 }
 
 /**
  * Keeps a single interstitial preloaded and reloads it after each show, so the
- * Save screen can present one immediately on demand.
+ * Save screen can present one immediately on demand. Holds the application
+ * context (never an Activity) so it's safe to retain across configuration changes.
  */
-class InterstitialController(private val context: Context) {
+class InterstitialController(context: Context) {
+    private val appContext = context.applicationContext
+    private val handler = Handler(Looper.getMainLooper())
     private var ad: InterstitialAd? = null
+    private var retryAttempt = 0
 
     fun load() {
         InterstitialAd.load(
-            context,
+            appContext,
             INTERSTITIAL_UNIT_ID,
             AdRequest.Builder().build(),
             object : InterstitialAdLoadCallback() {
                 override fun onAdLoaded(loaded: InterstitialAd) {
+                    retryAttempt = 0
                     loaded.fullScreenContentCallback = object : FullScreenContentCallback() {
                         override fun onAdDismissedFullScreenContent() {
                             ad = null
@@ -74,6 +83,13 @@ class InterstitialController(private val context: Context) {
 
                 override fun onAdFailedToLoad(error: LoadAdError) {
                     ad = null
+                    // Retry with capped exponential backoff so a transient network
+                    // failure doesn't disable interstitials for the whole session.
+                    if (retryAttempt < MAX_RETRIES) {
+                        retryAttempt++
+                        val delayMs = (1000L shl retryAttempt).coerceAtMost(60_000L)
+                        handler.postDelayed({ load() }, delayMs)
+                    }
                 }
             }
         )
@@ -82,10 +98,15 @@ class InterstitialController(private val context: Context) {
     fun showIfReady(activity: Activity) {
         ad?.show(activity)
     }
+
+    companion object {
+        private const val MAX_RETRIES = 5
+    }
 }
 
 @Composable
 fun rememberInterstitialController(): InterstitialController {
-    val context = LocalContext.current
-    return remember { InterstitialController(context).apply { load() } }
+    // Use the application context so the remembered controller never retains an Activity.
+    val context = LocalContext.current.applicationContext
+    return remember(context) { InterstitialController(context).apply { load() } }
 }

--- a/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
@@ -22,23 +22,24 @@ import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 
 // Real AdMob unit IDs (the AdMob app id lives in src/play/AndroidManifest.xml).
-// BANNER_UNIT_ID = "qard-bottom-banner"; INTERSTITIAL_UNIT_ID = "qard-interstitial".
+// "qard-bottom-banner", "qard-presets-ad" and "qard-interstitial" respectively.
 private const val BANNER_UNIT_ID = "ca-app-pub-7304740804770627/1570507628"
+private const val PRESETS_BANNER_UNIT_ID = "ca-app-pub-7304740804770627/9257425959"
 private const val INTERSTITIAL_UNIT_ID = "ca-app-pub-7304740804770627/6036324683"
 
 fun initAds(app: Application) {
     MobileAds.initialize(app) {}
 }
 
-/** A standard 320x50 banner; placed at the bottom of each screen. */
+/** A standard 320x50 banner for [unitId]; the AdView is released with the composable. */
 @Composable
-fun AdBanner(modifier: Modifier = Modifier) {
+private fun BannerAd(unitId: String, modifier: Modifier = Modifier) {
     AndroidView(
         modifier = modifier.fillMaxWidth(),
         factory = { ctx ->
             AdView(ctx).apply {
                 setAdSize(AdSize.BANNER)
-                adUnitId = BANNER_UNIT_ID
+                adUnitId = unitId
                 loadAd(AdRequest.Builder().build())
             }
         },
@@ -46,6 +47,14 @@ fun AdBanner(modifier: Modifier = Modifier) {
         onRelease = { adView -> adView.destroy() }
     )
 }
+
+/** Banner pinned to the bottom of every screen ("qard-bottom-banner"). */
+@Composable
+fun AdBanner(modifier: Modifier = Modifier) = BannerAd(BANNER_UNIT_ID, modifier)
+
+/** Banner shown within the Presets screen ("qard-presets-ad"). */
+@Composable
+fun PresetsAdBanner(modifier: Modifier = Modifier) = BannerAd(PRESETS_BANNER_UNIT_ID, modifier)
 
 /**
  * Keeps a single interstitial preloaded and reloads it after each show, so the
@@ -95,11 +104,21 @@ class InterstitialController(context: Context) {
     }
 
     fun showIfReady(activity: Activity) {
-        ad?.show(activity)
+        // Frequency cap: at most one interstitial per MIN_INTERVAL_MS (process-wide),
+        // so opening the Save screen repeatedly doesn't spam ads.
+        val now = System.currentTimeMillis()
+        if (now - lastShownAtMs < MIN_INTERVAL_MS) return
+        val current = ad ?: return
+        lastShownAtMs = now
+        current.show(activity)
     }
 
     companion object {
         private const val MAX_RETRIES = 5
+
+        // Minimum gap between interstitials, shared across controller instances.
+        private const val MIN_INTERVAL_MS = 60_000L
+        private var lastShownAtMs = 0L
     }
 }
 

--- a/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
@@ -1,0 +1,91 @@
+package com.hereliesaz.qard.ads
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+
+// Google's official TEST ad unit IDs. Replace with your real AdMob unit IDs before
+// publishing (the AdMob app id lives in src/play/AndroidManifest.xml). Using the
+// test IDs in development is required by AdMob policy to avoid invalid traffic.
+private const val BANNER_UNIT_ID = "ca-app-pub-3940256099942544/6300978111"
+private const val INTERSTITIAL_UNIT_ID = "ca-app-pub-3940256099942544/1033173712"
+
+fun initAds(app: Application) {
+    MobileAds.initialize(app) {}
+}
+
+/** A standard 320x50 banner; placed at the bottom of each screen. */
+@Composable
+fun AdBanner(modifier: Modifier = Modifier) {
+    AndroidView(
+        modifier = modifier.fillMaxWidth(),
+        factory = { ctx ->
+            AdView(ctx).apply {
+                setAdSize(AdSize.BANNER)
+                adUnitId = BANNER_UNIT_ID
+                loadAd(AdRequest.Builder().build())
+            }
+        }
+    )
+}
+
+/**
+ * Keeps a single interstitial preloaded and reloads it after each show, so the
+ * Save screen can present one immediately on demand.
+ */
+class InterstitialController(private val context: Context) {
+    private var ad: InterstitialAd? = null
+
+    fun load() {
+        InterstitialAd.load(
+            context,
+            INTERSTITIAL_UNIT_ID,
+            AdRequest.Builder().build(),
+            object : InterstitialAdLoadCallback() {
+                override fun onAdLoaded(loaded: InterstitialAd) {
+                    loaded.fullScreenContentCallback = object : FullScreenContentCallback() {
+                        override fun onAdDismissedFullScreenContent() {
+                            ad = null
+                            load()
+                        }
+
+                        override fun onAdFailedToShowFullScreenContent(error: AdError) {
+                            ad = null
+                            load()
+                        }
+                    }
+                    ad = loaded
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    ad = null
+                }
+            }
+        )
+    }
+
+    fun showIfReady(activity: Activity) {
+        ad?.show(activity)
+    }
+}
+
+@Composable
+fun rememberInterstitialController(): InterstitialController {
+    val context = LocalContext.current
+    return remember { InterstitialController(context).apply { load() } }
+}

--- a/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
+++ b/app/src/play/java/com/hereliesaz/qard/ads/Ads.kt
@@ -22,10 +22,9 @@ import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 
 // Real AdMob unit IDs (the AdMob app id lives in src/play/AndroidManifest.xml).
-// BANNER_UNIT_ID is the "qard-bottom-banner" unit. INTERSTITIAL_UNIT_ID is still
-// Google's official TEST unit id — replace it once a real interstitial unit exists.
+// BANNER_UNIT_ID = "qard-bottom-banner"; INTERSTITIAL_UNIT_ID = "qard-interstitial".
 private const val BANNER_UNIT_ID = "ca-app-pub-7304740804770627/1570507628"
-private const val INTERSTITIAL_UNIT_ID = "ca-app-pub-3940256099942544/1033173712"
+private const val INTERSTITIAL_UNIT_ID = "ca-app-pub-7304740804770627/6036324683"
 
 fun initAds(app: Application) {
     MobileAds.initialize(app) {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ qrcodeKotlinAndroid = "4.5.0"
 appcompat = "1.7.1" # Added appcompat version
 constraintlayout = "2.2.1" # Add this line for ConstraintLayout version
 navigationCompose = "2.9.8"
+playServicesAds = "23.6.0"
 
 [libraries]
 # Core & UI
@@ -32,6 +33,9 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" } # Added appcompat library
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Google AdMob
+play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }
 
 # Glance
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }


### PR DESCRIPTION
## What & why

You asked for AdMob ads in the **Play Store** build but the artifact the **GitHub repo compiles** to stay **ad-free**. This adds two product flavors:

| Flavor | Ads? | Who builds it |
|--------|------|----------------|
| **`foss`** (default) | **No** — no ad SDK, no AdMob manifest entries, ad calls are no-ops | The repo's CI (`build.yml`) compiles & publishes this to GitHub Releases |
| **`play`** | **Yes** — AdMob banner + interstitial | You build/upload this to the Play Store |

### How it's structured
- `app/src/foss/.../ads/Ads.kt` — no-op `initAds` / `AdBanner` / `rememberInterstitialController`. The FOSS APK pulls in **zero** ad code/SDK.
- `app/src/play/.../ads/Ads.kt` — real AdMob: `play-services-ads` via `playImplementation`, `MobileAds.initialize`, a 320×50 banner, and a preloaded interstitial.
- `app/src/play/AndroidManifest.xml` — `INTERNET` permission + AdMob `APPLICATION_ID` (play flavor only).
- Shared `QaRdApp`, `ConfigActivity`, `DetailActivity` call the same flavor-provided API, so both flavors compile identically.

### Behavior (play flavor)
- **Banner** pinned to the bottom of every editor screen (via the shared `onscreen` host) and the detail screen.
- **Interstitial** shown when the user opens the **Save** rail item.

### CI
- `build.yml` now builds **`assembleFossDebug`** and publishes `app/build/outputs/apk/foss/debug` — so the GitHub release stays ad-free.
- `android-ci.yml`'s `./gradlew build` compiles **both** flavors (verifies the AdMob code too).

### ⚠️ Before you publish to Play
The `play` flavor ships Google's official **TEST** ad unit IDs + test app id (required for safe development). Replace them with your real AdMob IDs:
- Unit IDs: `app/src/play/java/com/hereliesaz/qard/ads/Ads.kt` (`BANNER_UNIT_ID`, `INTERSTITIAL_UNIT_ID`)
- App id: `app/src/play/AndroidManifest.xml` (`com.google.android.gms.ads.APPLICATION_ID`)

> Not compiled locally (the Gradle daemon's network is sandboxed in this environment) — relying on CI to build both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Introduce separate FOSS and Play Store distributions with flavor-specific ad behavior and wiring, ensuring the GitHub-distributed APK remains ad-free while enabling AdMob in the Play build.

New Features:
- Add Play Store product flavor with AdMob banner and interstitial support and a shared ads API used by the UI screens.
- Introduce app-level Application class to initialize ads via flavor-specific implementations.
- Show banner ads in configuration/editor and detail screens and an additional banner on the presets screen in the Play flavor.
- Display an interstitial ad when navigating to the Save section in the Play flavor.

Enhancements:
- Add FOSS product flavor as the default, providing no-op ad implementations so the open-source build contains no ad SDK or ad logic.
- Refactor navigation layout in the config screen to host content above a bottom-pinned banner area without changing core behavior.
- Add AdMob dependency as a play-only implementation and wire up flavor-specific manifest entries for the Play build.

Build:
- Configure Gradle product flavors for ad-free FOSS and ad-enabled Play distributions and associate the AdMob library with the Play flavor only.

CI:
- Update GitHub Actions build workflow to assemble and publish the FOSS debug APK and adjust artifact discovery to the foss/debug output directory.