### PR TITLE
Dark-only theme with white text; open on Load

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -466,7 +466,7 @@ fun ConfigScreen(
         onscreen {
             Column(modifier = Modifier.fillMaxSize()) {
                 Box(modifier = Modifier.weight(1f)) {
-                    AzNavHost(startDestination = "data") {
+                    AzNavHost(startDestination = "load") {
                 composable("load") {
                     LoadScreen(dataStore = dataStore, updateConfig = loadSavedConfig)
                 }

--- a/app/src/main/java/com/hereliesaz/qard/ui/theme/QaRdTheme.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/theme/QaRdTheme.kt
@@ -1,72 +1,46 @@
 package com.hereliesaz.qard.ui.theme
 
-import android.app.Activity
-import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
+// Single dark theme with white text everywhere. Every `on*` role is white so all
+// Compose Text (which inherits its color from the active color scheme) renders white.
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
-    tertiary = Pink80
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
+    tertiary = Pink80,
     onPrimary = Color.White,
     onSecondary = Color.White,
     onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    onBackground = Color.White,
+    onSurface = Color.White,
+    onSurfaceVariant = Color.White,
+    onPrimaryContainer = Color.White,
+    onSecondaryContainer = Color.White,
+    onTertiaryContainer = Color.White,
+    onError = Color.White,
+    onErrorContainer = Color.White,
 )
 
 @Composable
 fun QaRdTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
+    val colorScheme = DarkColorScheme
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            (view.context as? androidx.activity.ComponentActivity)?.enableEdgeToEdge(
-                statusBarStyle = androidx.activity.SystemBarStyle.auto(
-                    android.graphics.Color.TRANSPARENT,
-                    android.graphics.Color.TRANSPARENT,
-                ) { darkTheme },
-                navigationBarStyle = androidx.activity.SystemBarStyle.auto(
-                    lightScrim = colorScheme.primary.toArgb(),
-                    darkScrim = colorScheme.primary.toArgb(),
-                ) { darkTheme },
+            (view.context as? ComponentActivity)?.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+                navigationBarStyle = SystemBarStyle.dark(colorScheme.primary.toArgb()),
             )
         }
     }


### PR DESCRIPTION
## What

- **Dark theme only, white text.** `QaRdTheme` no longer follows the system or dynamic color — it always uses a single dark scheme with every `on*` role set to `Color.White`, so all onscreen text (which inherits the scheme's content color) renders white. System bars are forced dark.
- **Open on Load.** The editor's `AzNavHost` now starts on the `load` route, so tapping the app icon lands on the Load screen.

Rail styling is untouched.

## Files
- `app/src/main/java/com/hereliesaz/qard/ui/theme/QaRdTheme.kt`
- `app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt` (one line: `startDestination = "load"`)

> Not compiled locally (sandboxed Gradle network) — CI builds both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Enforce a single dark theme with white text across the app and change the editor’s initial navigation route to open on the Load screen.

New Features:
- Start the editor navigation graph on the Load screen instead of the Data screen.

Enhancements:
- Simplify theming to a single dark Material 3 color scheme with all on* roles set to white and force dark system bars.