### PR TITLE
Import a contact via the device picker into the Contact QR

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
+    <!-- Lets the user import a contact (incl. Google-synced ones) into a Contact QR. -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <application
         android:name=".QaRdApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -7,6 +7,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.ContactsContract
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -974,7 +976,58 @@ fun SaveScreen(
 
 @Composable
 fun ContactForm(contact: QrData.Contact, onContactChange: (QrData.Contact) -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    // System contact picker — lists the user's Google-synced contacts (and any others).
+    val pickContact = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickContact()
+    ) { uri ->
+        if (uri != null) {
+            scope.launch {
+                val picked = withContext(Dispatchers.IO) { readContact(context, uri) }
+                if (picked != null) {
+                    onContactChange(picked)
+                } else {
+                    Toast.makeText(context, "Couldn't read that contact", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    val contactsPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            pickContact.launch(null)
+        } else {
+            Toast.makeText(
+                context,
+                "Contacts permission is needed to import a contact",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(
+            onClick = {
+                val hasPermission = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.READ_CONTACTS
+                ) == PackageManager.PERMISSION_GRANTED
+                if (hasPermission) {
+                    pickContact.launch(null)
+                } else {
+                    contactsPermissionLauncher.launch(Manifest.permission.READ_CONTACTS)
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Default.Person, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Pick from contacts")
+        }
         OutlinedTextField(
             value = contact.name,
             onValueChange = { onContactChange(contact.copy(name = it)) },
@@ -1006,6 +1059,61 @@ fun ContactForm(contact: QrData.Contact, onContactChange: (QrData.Contact) -> Un
             modifier = Modifier.fillMaxWidth()
         )
     }
+}
+
+/**
+ * Reads the picked contact's name/phone/email/organization/website from the
+ * contacts provider (requires READ_CONTACTS). Returns null if nothing usable.
+ */
+private fun readContact(context: Context, contactUri: Uri): QrData.Contact? {
+    val resolver = context.contentResolver
+    val contactId = resolver.query(
+        contactUri,
+        arrayOf(ContactsContract.Contacts._ID),
+        null, null, null
+    )?.use { c -> if (c.moveToFirst()) c.getString(0) else null } ?: return null
+
+    var name = ""
+    var phone = ""
+    var email = ""
+    var organization = ""
+    var website = ""
+
+    resolver.query(
+        ContactsContract.Data.CONTENT_URI,
+        arrayOf(ContactsContract.Data.MIMETYPE, ContactsContract.Data.DATA1),
+        "${ContactsContract.Data.CONTACT_ID} = ?",
+        arrayOf(contactId),
+        null
+    )?.use { c ->
+        val mimeIdx = c.getColumnIndexOrThrow(ContactsContract.Data.MIMETYPE)
+        val dataIdx = c.getColumnIndexOrThrow(ContactsContract.Data.DATA1)
+        while (c.moveToNext()) {
+            val value = c.getString(dataIdx)?.trim().orEmpty()
+            if (value.isEmpty()) continue
+            when (c.getString(mimeIdx)) {
+                ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE ->
+                    if (name.isEmpty()) name = value
+                ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE ->
+                    if (phone.isEmpty()) phone = value
+                ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE ->
+                    if (email.isEmpty()) email = value
+                ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE ->
+                    if (organization.isEmpty()) organization = value
+                ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE ->
+                    if (website.isEmpty()) website = value
+            }
+        }
+    }
+
+    if (name.isEmpty() && phone.isEmpty() && email.isEmpty()) return null
+    return QrData.Contact(
+        name = name,
+        phone = phone,
+        email = email,
+        organization = organization,
+        website = website,
+    )
 }
 
 @Composable


### PR DESCRIPTION
## What

Adds a **"Pick from contacts"** button to the Contact data form. It opens Android's system contact picker — which lists the user's **Google-synced contacts** (and any others on the device) — and fills the Contact QR fields (name, phone, email, organization, website) from the chosen contact.

## How
- `ContactForm` gains a button that checks/requests `READ_CONTACTS`, then launches `ActivityResultContracts.PickContact()`.
- `readContact(...)` queries the contacts provider (`ContactsContract.Data`, filtered by contact id) on a background dispatcher and maps the rows into `QrData.Contact`; the user can still edit the fields after import.
- `READ_CONTACTS` added to the manifest with a runtime permission request (graceful toast if denied).

## Files
- `app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt`
- `app/src/main/AndroidManifest.xml`

> Device contact picker chosen over the Google People API (no sign-in/OAuth; Google contacts are already synced into the device contacts). Not compiled locally (sandboxed Gradle) — CI builds both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Add support for importing device contacts into the Contact QR configuration form.

New Features:
- Allow users to pick a contact from the device contact picker to populate the Contact QR form fields.
- Populate contact name, phone, email, organization, and website fields from the selected contact when available.

Enhancements:
- Request and handle READ_CONTACTS runtime permission when importing a contact, with user feedback on denial.