### PR TITLE
Full Contact fields + custom fields; single Link; Link/Contact exclusive

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
@@ -17,16 +17,37 @@ sealed class QrData {
 
     @Serializable
     data class Contact(
-        val name: String = "",
-        val phone: String = "",
-        val email: String = "",
+        val firstName: String = "",
+        val lastName: String = "",
         val organization: String = "",
-        val website: String = "",
+        val title: String = "",
+        val phones: List<LabeledValue> = emptyList(),
+        val emails: List<LabeledValue> = emptyList(),
+        val addresses: List<LabeledValue> = emptyList(),
+        val websites: List<LabeledValue> = emptyList(),
+        val birthday: String = "",
+        val note: String = "",
+        // Anything else the user wants to add (label + value).
+        val customFields: List<LabeledValue> = emptyList(),
     ) : QrData()
 
     @Serializable
     data class SocialMedia(val links: List<SocialLink> = emptyList()) : QrData()
 }
+
+/** A value with a user-facing label, e.g. ("Mobile", "+1 555…") or ("Work", "…"). */
+@Serializable
+data class LabeledValue(val label: String = "", val value: String = "")
+
+fun QrData.Contact.displayName(): String =
+    listOf(firstName, lastName).filter { it.isNotBlank() }.joinToString(" ").trim()
+
+fun QrData.Contact.hasInfo(): Boolean =
+    firstName.isNotBlank() || lastName.isNotBlank() || organization.isNotBlank() ||
+        title.isNotBlank() || birthday.isNotBlank() || note.isNotBlank() ||
+        phones.any { it.value.isNotBlank() } || emails.any { it.value.isNotBlank() } ||
+        addresses.any { it.value.isNotBlank() } || websites.any { it.value.isNotBlank() } ||
+        customFields.any { it.value.isNotBlank() }
 
 @Serializable
 data class SocialLink(

--- a/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
@@ -13,6 +13,10 @@ import kotlinx.serialization.json.Json
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "qr_configs_data_store")
 
+// Tolerate configs written by older app versions whose data model has since
+// changed (e.g. the Contact fields) instead of throwing on unknown keys.
+private val json = Json { ignoreUnknownKeys = true }
+
 class QrDataStore(private val context: Context) {
 
     companion object {
@@ -29,7 +33,7 @@ class QrDataStore(private val context: Context) {
                 Log.d("QrDataStore", "Loading config for widget $appWidgetId: $jsonString")
                 if (jsonString != null) {
                     try {
-                        Json.decodeFromString<QrConfig>(jsonString)
+                        json.decodeFromString<QrConfig>(jsonString)
                     } catch (e: Exception) {
                         Log.e(
                             "QrDataStore",
@@ -46,7 +50,7 @@ class QrDataStore(private val context: Context) {
     suspend fun saveConfig(appWidgetId: Int, config: QrConfig) {
         val key = qrConfigKey(appWidgetId)
         context.dataStore.edit { preferences ->
-            val jsonString = Json.encodeToString(config)
+            val jsonString = json.encodeToString(config)
             Log.d("QrDataStore", "Saving config for widget $appWidgetId: $jsonString")
             preferences[key] = jsonString
         }
@@ -64,7 +68,7 @@ class QrDataStore(private val context: Context) {
             val jsonString = preferences[SAVED_CONFIGS_KEY]
             if (jsonString != null) {
                 try {
-                    Json.decodeFromString<List<QrConfig>>(jsonString)
+                    json.decodeFromString<List<QrConfig>>(jsonString)
                 } catch (e: Exception) {
                     emptyList()
                 }
@@ -76,7 +80,7 @@ class QrDataStore(private val context: Context) {
 
     suspend fun saveConfigs(configs: List<QrConfig>) {
         context.dataStore.edit { preferences ->
-            preferences[SAVED_CONFIGS_KEY] = Json.encodeToString(configs)
+            preferences[SAVED_CONFIGS_KEY] = json.encodeToString(configs)
         }
     }
 
@@ -87,7 +91,7 @@ class QrDataStore(private val context: Context) {
      */
     suspend fun savePendingPinConfig(config: QrConfig) {
         context.dataStore.edit { preferences ->
-            preferences[PENDING_PIN_CONFIG_KEY] = Json.encodeToString(config)
+            preferences[PENDING_PIN_CONFIG_KEY] = json.encodeToString(config)
         }
     }
 
@@ -98,7 +102,7 @@ class QrDataStore(private val context: Context) {
             val jsonString = preferences[PENDING_PIN_CONFIG_KEY]
             if (jsonString != null) {
                 result = try {
-                    Json.decodeFromString<QrConfig>(jsonString)
+                    json.decodeFromString<QrConfig>(jsonString)
                 } catch (e: Exception) {
                     null
                 }

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -99,12 +99,14 @@ import com.godaddy.android.colorpicker.HsvColor
 import com.hereliesaz.aznavrail.*
 import com.hereliesaz.qard.data.BackgroundType
 import com.hereliesaz.qard.data.ForegroundType
+import com.hereliesaz.qard.data.LabeledValue
 import com.hereliesaz.qard.data.QrConfig
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.data.QrDataStore
 import com.hereliesaz.qard.data.QrDataType
 import com.hereliesaz.qard.data.QrShape
 import com.hereliesaz.qard.data.SocialLink
+import com.hereliesaz.qard.data.hasInfo
 import com.hereliesaz.qard.ads.AdBanner
 import com.hereliesaz.qard.ads.PresetsAdBanner
 import com.hereliesaz.qard.ads.rememberInterstitialController
@@ -227,7 +229,7 @@ private fun QrData.dataType(): QrDataType = when (this) {
 }
 
 private fun dataTypeLabel(type: QrDataType): String = when (type) {
-    QrDataType.Links -> "Links"
+    QrDataType.Links -> "Link"
     QrDataType.Contact -> "Contact"
     QrDataType.SocialMedia -> "Social Media"
 }
@@ -261,10 +263,14 @@ private fun replaceData(
 private fun QrConfig.hasContent(): Boolean = data.any {
     when (it) {
         is QrData.Links -> it.links.any { link -> link.isNotBlank() }
-        is QrData.Contact -> it.name.isNotBlank()
+        is QrData.Contact -> it.hasInfo()
         is QrData.SocialMedia -> it.links.any { social -> social.url.isNotBlank() }
     }
 }
+
+// Link and Contact are mutually exclusive — a code is either a single link or a
+// contact card, not both. Social Media can accompany either.
+private val mutuallyExclusiveTypes = setOf(QrDataType.Links, QrDataType.Contact)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -654,7 +660,11 @@ private fun DataTypeSection(
                     onCheckedChange = { isOn ->
                         val data = currentConfig.data.toMutableList()
                         if (isOn) {
-                            if (existing == null) data.add(defaultDataFor(type))
+                            // Turning on Link or Contact removes the other (mutually exclusive).
+                            if (type in mutuallyExclusiveTypes) {
+                                data.removeAll { it.dataType() in mutuallyExclusiveTypes }
+                            }
+                            if (data.none { it.dataType() == type }) data.add(defaultDataFor(type))
                         } else {
                             data.removeAll { it.dataType() == type }
                         }
@@ -1030,42 +1040,113 @@ fun ContactForm(contact: QrData.Contact, onContactChange: (QrData.Contact) -> Un
             Spacer(modifier = Modifier.width(8.dp))
             Text("Pick from contacts")
         }
-        OutlinedTextField(
-            value = contact.name,
-            onValueChange = { onContactChange(contact.copy(name = it)) },
-            label = { Text("Name") },
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = contact.phone,
-            onValueChange = { onContactChange(contact.copy(phone = it)) },
-            label = { Text("Phone") },
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = contact.email,
-            onValueChange = { onContactChange(contact.copy(email = it)) },
-            label = { Text("Email") },
-            modifier = Modifier.fillMaxWidth()
-        )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            OutlinedTextField(
+                value = contact.firstName,
+                onValueChange = { onContactChange(contact.copy(firstName = it)) },
+                label = { Text("First name") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            OutlinedTextField(
+                value = contact.lastName,
+                onValueChange = { onContactChange(contact.copy(lastName = it)) },
+                label = { Text("Last name") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
         OutlinedTextField(
             value = contact.organization,
             onValueChange = { onContactChange(contact.copy(organization = it)) },
             label = { Text("Organization") },
+            singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )
         OutlinedTextField(
-            value = contact.website,
-            onValueChange = { onContactChange(contact.copy(website = it)) },
-            label = { Text("Website") },
+            value = contact.title,
+            onValueChange = { onContactChange(contact.copy(title = it)) },
+            label = { Text("Title") },
+            singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )
+        LabeledValueSection("Phones", contact.phones, "Phone") {
+            onContactChange(contact.copy(phones = it))
+        }
+        LabeledValueSection("Emails", contact.emails, "Email") {
+            onContactChange(contact.copy(emails = it))
+        }
+        LabeledValueSection("Addresses", contact.addresses, "Address") {
+            onContactChange(contact.copy(addresses = it))
+        }
+        LabeledValueSection("Websites", contact.websites, "Website") {
+            onContactChange(contact.copy(websites = it))
+        }
+        OutlinedTextField(
+            value = contact.birthday,
+            onValueChange = { onContactChange(contact.copy(birthday = it)) },
+            label = { Text("Birthday") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = contact.note,
+            onValueChange = { onContactChange(contact.copy(note = it)) },
+            label = { Text("Note") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        LabeledValueSection("Custom fields", contact.customFields, "Value") {
+            onContactChange(contact.copy(customFields = it))
+        }
+    }
+}
+
+/** A repeatable list of (label, value) rows with per-row delete and an Add button. */
+@Composable
+private fun LabeledValueSection(
+    title: String,
+    items: List<LabeledValue>,
+    valueLabel: String,
+    onChange: (List<LabeledValue>) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(title, style = MaterialTheme.typography.titleSmall)
+        items.forEachIndexed { index, item ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(
+                    value = item.label,
+                    onValueChange = { newLabel ->
+                        onChange(items.toMutableList().apply { set(index, item.copy(label = newLabel)) })
+                    },
+                    label = { Text("Label") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                OutlinedTextField(
+                    value = item.value,
+                    onValueChange = { newValue ->
+                        onChange(items.toMutableList().apply { set(index, item.copy(value = newValue)) })
+                    },
+                    label = { Text(valueLabel) },
+                    singleLine = true,
+                    modifier = Modifier.weight(2f)
+                )
+                IconButton(onClick = { onChange(items.filterIndexed { i, _ -> i != index }) }) {
+                    Icon(Icons.Default.Delete, contentDescription = "Remove")
+                }
+            }
+        }
+        OutlinedButton(onClick = { onChange(items + LabeledValue()) }) {
+            Text("Add")
+        }
     }
 }
 
 /**
- * Reads the picked contact's name/phone/email/organization/website from the
- * contacts provider (requires READ_CONTACTS). Returns null if nothing usable.
+ * Reads the picked contact's details from the contacts provider (requires
+ * READ_CONTACTS) into the structured Contact model. Returns null if empty.
  */
 private fun readContact(context: Context, contactUri: Uri): QrData.Contact? {
     val resolver = context.contentResolver
@@ -1083,37 +1164,61 @@ private fun readContact(context: Context, contactUri: Uri): QrData.Contact? {
         null
     } ?: return null
 
-    var name = ""
-    var phone = ""
-    var email = ""
+    var firstName = ""
+    var lastName = ""
     var organization = ""
-    var website = ""
+    var title = ""
+    val phones = mutableListOf<LabeledValue>()
+    val emails = mutableListOf<LabeledValue>()
+    val addresses = mutableListOf<LabeledValue>()
+    val websites = mutableListOf<LabeledValue>()
 
     try {
         resolver.query(
             ContactsContract.Data.CONTENT_URI,
-            arrayOf(ContactsContract.Data.MIMETYPE, ContactsContract.Data.DATA1),
+            arrayOf(
+                ContactsContract.Data.MIMETYPE,
+                ContactsContract.Data.DATA1,
+                ContactsContract.Data.DATA2,
+                ContactsContract.Data.DATA3,
+                ContactsContract.Data.DATA4,
+            ),
             "${ContactsContract.Data.CONTACT_ID} = ?",
             arrayOf(contactId),
             null
         )?.use { c ->
             val mimeIdx = c.getColumnIndex(ContactsContract.Data.MIMETYPE)
-            val dataIdx = c.getColumnIndex(ContactsContract.Data.DATA1)
-            if (mimeIdx != -1 && dataIdx != -1) {
+            val d1 = c.getColumnIndex(ContactsContract.Data.DATA1)
+            val d2 = c.getColumnIndex(ContactsContract.Data.DATA2)
+            val d3 = c.getColumnIndex(ContactsContract.Data.DATA3)
+            val d4 = c.getColumnIndex(ContactsContract.Data.DATA4)
+            if (mimeIdx != -1 && d1 != -1) {
+                fun col(i: Int) = if (i != -1) c.getString(i)?.trim().orEmpty() else ""
                 while (c.moveToNext()) {
-                    val value = c.getString(dataIdx)?.trim().orEmpty()
-                    if (value.isEmpty()) continue
+                    val v1 = col(d1)
                     when (c.getString(mimeIdx)) {
-                        ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE ->
-                            if (name.isEmpty()) name = value
+                        ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE -> {
+                            val given = col(d2)
+                            val family = col(d3)
+                            if (given.isNotEmpty() || family.isNotEmpty()) {
+                                if (firstName.isEmpty()) firstName = given
+                                if (lastName.isEmpty()) lastName = family
+                            } else if (firstName.isEmpty() && v1.isNotEmpty()) {
+                                firstName = v1
+                            }
+                        }
                         ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE ->
-                            if (phone.isEmpty()) phone = value
+                            if (v1.isNotEmpty()) phones += LabeledValue("Phone", v1)
                         ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE ->
-                            if (email.isEmpty()) email = value
-                        ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE ->
-                            if (organization.isEmpty()) organization = value
+                            if (v1.isNotEmpty()) emails += LabeledValue("Email", v1)
+                        ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE ->
+                            if (v1.isNotEmpty()) addresses += LabeledValue("Address", v1)
                         ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE ->
-                            if (website.isEmpty()) website = value
+                            if (v1.isNotEmpty()) websites += LabeledValue("Website", v1)
+                        ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE -> {
+                            if (organization.isEmpty()) organization = v1
+                            if (title.isEmpty()) title = col(d4)
+                        }
                     }
                 }
             }
@@ -1122,32 +1227,28 @@ private fun readContact(context: Context, contactUri: Uri): QrData.Contact? {
         Log.e("ConfigActivity", "Failed to query contact details", e)
     }
 
-    if (name.isEmpty() && phone.isEmpty() && email.isEmpty()) return null
-    return QrData.Contact(
-        name = name,
-        phone = phone,
-        email = email,
+    val contact = QrData.Contact(
+        firstName = firstName,
+        lastName = lastName,
         organization = organization,
-        website = website,
+        title = title,
+        phones = phones,
+        emails = emails,
+        addresses = addresses,
+        websites = websites,
     )
+    return if (contact.hasInfo()) contact else null
 }
 
 @Composable
 fun LinksForm(links: QrData.Links, onLinksChange: (QrData.Links) -> Unit) {
-    EditableList(
-        items = links.links,
-        onAdd = { onLinksChange(links.copy(links = links.links + "")) },
-        onRemove = { index -> onLinksChange(links.copy(links = links.links.filterIndexed { i, _ -> i != index })) },
-        itemContent = { index, item ->
-            OutlinedTextField(
-                value = item,
-                onValueChange = { newItem ->
-                    onLinksChange(links.copy(links = links.links.toMutableList().apply { set(index, newItem) }))
-                },
-                label = { Text("Link to File") },
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
+    // A single link only.
+    OutlinedTextField(
+        value = links.links.firstOrNull().orEmpty(),
+        onValueChange = { newUrl -> onLinksChange(links.copy(links = listOf(newUrl))) },
+        label = { Text("Link") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth()
     )
 }
 

--- a/app/src/main/java/com/hereliesaz/qard/ui/DetailActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/DetailActivity.kt
@@ -44,6 +44,7 @@ import com.hereliesaz.qard.ads.AdBanner
 import com.hereliesaz.qard.data.QrConfig
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.data.QrDataStore
+import com.hereliesaz.qard.data.displayName
 import com.hereliesaz.qard.ui.theme.QaRdTheme
 import com.hereliesaz.qard.widget.QrGenerator
 import kotlinx.coroutines.flow.first
@@ -173,12 +174,26 @@ fun QrCodeDetailScreen(config: QrConfig, onBack: () -> Unit) {
                         InfoRow(label = "Link", value = link) { openUrl(context, link) }
                     }
                     is QrData.Contact -> {
-                        if (data.name.isNotBlank()) InfoRow("Name", data.name)
-                        if (data.phone.isNotBlank()) InfoRow("Phone", data.phone)
-                        if (data.email.isNotBlank()) InfoRow("Email", data.email)
+                        val name = data.displayName()
+                        if (name.isNotBlank()) InfoRow("Name", name)
                         if (data.organization.isNotBlank()) InfoRow("Organization", data.organization)
-                        if (data.website.isNotBlank()) {
-                            InfoRow("Website", data.website) { openUrl(context, data.website) }
+                        if (data.title.isNotBlank()) InfoRow("Title", data.title)
+                        data.phones.filter { it.value.isNotBlank() }.forEach {
+                            InfoRow(it.label.ifBlank { "Phone" }, it.value)
+                        }
+                        data.emails.filter { it.value.isNotBlank() }.forEach {
+                            InfoRow(it.label.ifBlank { "Email" }, it.value)
+                        }
+                        data.addresses.filter { it.value.isNotBlank() }.forEach {
+                            InfoRow(it.label.ifBlank { "Address" }, it.value)
+                        }
+                        data.websites.filter { it.value.isNotBlank() }.forEach {
+                            InfoRow(it.label.ifBlank { "Website" }, it.value) { openUrl(context, it.value) }
+                        }
+                        if (data.birthday.isNotBlank()) InfoRow("Birthday", data.birthday)
+                        if (data.note.isNotBlank()) InfoRow("Note", data.note)
+                        data.customFields.filter { it.value.isNotBlank() }.forEach {
+                            InfoRow(it.label.ifBlank { "Field" }, it.value)
                         }
                     }
                     is QrData.SocialMedia -> data.links.filter { it.url.isNotBlank() }.forEach { social ->

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrGenerator.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrGenerator.kt
@@ -117,24 +117,55 @@ object QrGenerator {
     private fun escapeVCard(value: String): String =
         value.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
 
-    private fun createVCard(contact: QrData.Contact, socialLinks: List<com.hereliesaz.qard.data.SocialLink>, links: List<String>): String {
-        val socialLinksStr = socialLinks.filter { it.url.isNotBlank() }.joinToString("\n") {
-            "X-SOCIALPROFILE;type=${escapeVCard(it.platform)}:${it.url}"
+    private fun vcardType(label: String): String {
+        val t = label.trim()
+        return if (t.isEmpty()) "" else ";TYPE=${escapeVCard(t)}"
+    }
+
+    private fun createVCard(
+        contact: QrData.Contact,
+        socialLinks: List<com.hereliesaz.qard.data.SocialLink>,
+        links: List<String>
+    ): String {
+        val lines = mutableListOf("BEGIN:VCARD", "VERSION:3.0")
+
+        val first = contact.firstName.trim()
+        val last = contact.lastName.trim()
+        if (first.isNotBlank() || last.isNotBlank()) {
+            lines += "N:${escapeVCard(last)};${escapeVCard(first)};;;"
+            lines += "FN:${escapeVCard(listOf(first, last).filter { it.isNotBlank() }.joinToString(" "))}"
         }
-        val linksStr = links.filter { it.isNotBlank() }.joinToString("\n") {
-            "URL:$it"
+        if (contact.organization.isNotBlank()) lines += "ORG:${escapeVCard(contact.organization)}"
+        if (contact.title.isNotBlank()) lines += "TITLE:${escapeVCard(contact.title)}"
+
+        contact.phones.filter { it.value.isNotBlank() }.forEach {
+            lines += "TEL${vcardType(it.label)}:${escapeVCard(it.value)}"
         }
-        return """
-            BEGIN:VCARD
-            VERSION:3.0
-            N:${escapeVCard(contact.name)}
-            ORG:${escapeVCard(contact.organization)}
-            TEL:${escapeVCard(contact.phone)}
-            URL:${contact.website}
-            EMAIL:${contact.email}
-            $socialLinksStr
-            $linksStr
-            END:VCARD
-        """.trimIndent()
+        contact.emails.filter { it.value.isNotBlank() }.forEach {
+            lines += "EMAIL${vcardType(it.label)}:${escapeVCard(it.value)}"
+        }
+        contact.addresses.filter { it.value.isNotBlank() }.forEach {
+            // Freeform address goes in the street component of ADR.
+            lines += "ADR${vcardType(it.label)}:;;${escapeVCard(it.value)};;;;"
+        }
+        contact.websites.filter { it.value.isNotBlank() }.forEach {
+            lines += "URL:${it.value.trim()}"
+        }
+        links.filter { it.isNotBlank() }.forEach { lines += "URL:${it.trim()}" }
+
+        if (contact.birthday.isNotBlank()) lines += "BDAY:${escapeVCard(contact.birthday)}"
+
+        socialLinks.filter { it.url.isNotBlank() }.forEach {
+            lines += "X-SOCIALPROFILE;TYPE=${escapeVCard(it.platform)}:${it.url}"
+        }
+
+        val noteParts = (listOf(contact.note) + contact.customFields
+            .filter { it.value.isNotBlank() }
+            .map { "${it.label.ifBlank { "Note" }}: ${it.value}" })
+            .filter { it.isNotBlank() }
+        if (noteParts.isNotEmpty()) lines += "NOTE:${escapeVCard(noteParts.joinToString(" | "))}"
+
+        lines += "END:VCARD"
+        return lines.joinToString("\n")
     }
 }

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
@@ -28,6 +28,7 @@ import androidx.glance.layout.padding
 import androidx.glance.text.Text
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.data.QrDataStore
+import com.hereliesaz.qard.data.hasInfo
 
 class QrWidget : GlanceAppWidget() {
 
@@ -68,7 +69,7 @@ class QrWidget : GlanceAppWidget() {
                     val dataIsNotBlank = currentConfig.data.any {
                         when (it) {
                             is QrData.Links -> it.links.any { link -> link.isNotBlank() }
-                            is QrData.Contact -> it.name.isNotBlank()
+                            is QrData.Contact -> it.hasInfo()
                             is QrData.SocialMedia -> it.links.any { social -> social.url.isNotBlank() }
                         }
                     }


### PR DESCRIPTION
## What

Three related data-type changes:

### 1. Comprehensive Contact (vCard) fields + custom fields
`QrData.Contact` is now a full contact model:
- First / last name, organization, title
- **Repeatable, labeled** phones, emails, addresses, websites (add/remove rows — the "add fields" ask)
- Birthday, note
- **Custom fields** (user-defined label + value)

`ContactForm` rebuilt accordingly; the **contact picker** import now maps name parts, all phones/emails, postal addresses, websites, and org + title. `QrGenerator` emits a richer vCard (`N`/`FN`/`ORG`/`TITLE`/`TEL`/`EMAIL`/`ADR`/`URL`/`BDAY`/`NOTE` + `X-SOCIALPROFILE`); `DetailActivity` lists every field. New `displayName()`/`hasInfo()` helpers replace the old single-field checks in the widget and editor.

### 2. Link is singular
"Links" → **"Link"**: a single URL field (no add-more list).

### 3. Link ⊻ Contact
Link and Contact are **mutually exclusive** — enabling one turns the other off (a code is either a single link or a contact card). Social Media still accompanies either.

### Compatibility
`QrDataStore` now decodes with `ignoreUnknownKeys`, so configs written with the old Contact shape load without crashing (old contact fields are dropped, the rest of the config is preserved).

## Files
- `data/QrConfig.kt`, `data/QrDataStore.kt`
- `ui/ConfigActivity.kt`, `ui/DetailActivity.kt`
- `widget/QrGenerator.kt`, `widget/QrWidget.kt`

> Not compiled locally (sandboxed Gradle) — CI builds both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Expand contact QR data to a full vCard-style contact model, make QR codes support a single link field instead of multiple, and ensure link and contact payloads are mutually exclusive while preserving compatibility with older saved configs.

New Features:
- Support a structured contact model with separate name parts, organization, title, multiple labeled phones/emails/addresses/websites, birthday, note, and custom fields.
- Import rich contact details from the system contact picker into the structured contact model.
- Generate richer vCard output including full name, organization, title, multiple contact channels, birthday, social profiles, and aggregated notes from custom fields.

Bug Fixes:
- Make config JSON (de)serialization tolerant of unknown keys so older configs with outdated contact shapes no longer fail to load.

Enhancements:
- Update the contact configuration form and detail screen to edit and display all structured contact fields and repeatable labeled values.
- Introduce helpers to compute a contact display name and detect whether a contact contains any meaningful information.
- Restrict the link configuration UI to a single URL field and relabel the data type from "Links" to "Link".
- Enforce mutual exclusivity between link and contact data types in a QR config while allowing social media to coexist.