### PR TITLE
Claude/contact fields

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.qard.data
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 enum class QrDataType {
@@ -29,6 +30,13 @@ sealed class QrData {
         val note: String = "",
         // Anything else the user wants to add (label + value).
         val customFields: List<LabeledValue> = emptyList(),
+        // Legacy single-value fields from before the restructure. Kept only so
+        // older saved configs migrate into the new fields instead of losing data;
+        // always null in newly written configs (see migrated()).
+        @SerialName("name") val legacyName: String? = null,
+        @SerialName("phone") val legacyPhone: String? = null,
+        @SerialName("email") val legacyEmail: String? = null,
+        @SerialName("website") val legacyWebsite: String? = null,
     ) : QrData()
 
     @Serializable
@@ -48,6 +56,32 @@ fun QrData.Contact.hasInfo(): Boolean =
         phones.any { it.value.isNotBlank() } || emails.any { it.value.isNotBlank() } ||
         addresses.any { it.value.isNotBlank() } || websites.any { it.value.isNotBlank() } ||
         customFields.any { it.value.isNotBlank() }
+
+/** Maps any legacy single-value Contact fields into the structured fields. */
+fun QrData.Contact.migrated(): QrData.Contact {
+    if (legacyName.isNullOrBlank() && legacyPhone.isNullOrBlank() &&
+        legacyEmail.isNullOrBlank() && legacyWebsite.isNullOrBlank()
+    ) {
+        return this
+    }
+    return copy(
+        firstName = if (firstName.isBlank() && lastName.isBlank()) legacyName.orEmpty() else firstName,
+        phones = if (phones.isEmpty() && !legacyPhone.isNullOrBlank())
+            listOf(LabeledValue("Phone", legacyPhone.orEmpty())) else phones,
+        emails = if (emails.isEmpty() && !legacyEmail.isNullOrBlank())
+            listOf(LabeledValue("Email", legacyEmail.orEmpty())) else emails,
+        websites = if (websites.isEmpty() && !legacyWebsite.isNullOrBlank())
+            listOf(LabeledValue("Website", legacyWebsite.orEmpty())) else websites,
+        legacyName = null,
+        legacyPhone = null,
+        legacyEmail = null,
+        legacyWebsite = null,
+    )
+}
+
+/** Migrates every Contact in the config (call after loading from storage). */
+fun QrConfig.migrated(): QrConfig =
+    copy(data = data.map { if (it is QrData.Contact) it.migrated() else it })
 
 @Serializable
 data class SocialLink(

--- a/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
@@ -33,7 +33,7 @@ class QrDataStore(private val context: Context) {
                 Log.d("QrDataStore", "Loading config for widget $appWidgetId: $jsonString")
                 if (jsonString != null) {
                     try {
-                        json.decodeFromString<QrConfig>(jsonString)
+                        json.decodeFromString<QrConfig>(jsonString).migrated()
                     } catch (e: Exception) {
                         Log.e(
                             "QrDataStore",
@@ -68,7 +68,7 @@ class QrDataStore(private val context: Context) {
             val jsonString = preferences[SAVED_CONFIGS_KEY]
             if (jsonString != null) {
                 try {
-                    json.decodeFromString<List<QrConfig>>(jsonString)
+                    json.decodeFromString<List<QrConfig>>(jsonString).map { it.migrated() }
                 } catch (e: Exception) {
                     emptyList()
                 }
@@ -102,7 +102,7 @@ class QrDataStore(private val context: Context) {
             val jsonString = preferences[PENDING_PIN_CONFIG_KEY]
             if (jsonString != null) {
                 result = try {
-                    json.decodeFromString<QrConfig>(jsonString)
+                    json.decodeFromString<QrConfig>(jsonString).migrated()
                 } catch (e: Exception) {
                     null
                 }

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -1138,7 +1138,11 @@ private fun LabeledValueSection(
                 }
             }
         }
-        OutlinedButton(onClick = { onChange(items + LabeledValue()) }) {
+        // Don't let empty rows pile up.
+        OutlinedButton(
+            onClick = { onChange(items + LabeledValue()) },
+            enabled = items.isEmpty() || items.last().value.isNotBlank()
+        ) {
             Text("Add")
         }
     }
@@ -1208,11 +1212,29 @@ private fun readContact(context: Context, contactUri: Uri): QrData.Contact? {
                             }
                         }
                         ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE ->
-                            if (v1.isNotEmpty()) phones += LabeledValue("Phone", v1)
+                            if (v1.isNotEmpty()) {
+                                val type = col(d2).toIntOrNull()
+                                    ?: ContactsContract.CommonDataKinds.Phone.TYPE_OTHER
+                                val label = ContactsContract.CommonDataKinds.Phone
+                                    .getTypeLabel(context.resources, type, col(d3)).toString()
+                                phones += LabeledValue(label.ifBlank { "Phone" }, v1)
+                            }
                         ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE ->
-                            if (v1.isNotEmpty()) emails += LabeledValue("Email", v1)
+                            if (v1.isNotEmpty()) {
+                                val type = col(d2).toIntOrNull()
+                                    ?: ContactsContract.CommonDataKinds.Email.TYPE_OTHER
+                                val label = ContactsContract.CommonDataKinds.Email
+                                    .getTypeLabel(context.resources, type, col(d3)).toString()
+                                emails += LabeledValue(label.ifBlank { "Email" }, v1)
+                            }
                         ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE ->
-                            if (v1.isNotEmpty()) addresses += LabeledValue("Address", v1)
+                            if (v1.isNotEmpty()) {
+                                val type = col(d2).toIntOrNull()
+                                    ?: ContactsContract.CommonDataKinds.StructuredPostal.TYPE_OTHER
+                                val label = ContactsContract.CommonDataKinds.StructuredPostal
+                                    .getTypeLabel(context.resources, type, col(d3)).toString()
+                                addresses += LabeledValue(label.ifBlank { "Address" }, v1)
+                            }
                         ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE ->
                             if (v1.isNotEmpty()) websites += LabeledValue("Website", v1)
                         ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE -> {

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrGenerator.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrGenerator.kt
@@ -122,6 +122,11 @@ object QrGenerator {
         return if (t.isEmpty()) "" else ";TYPE=${escapeVCard(t)}"
     }
 
+    // URLs are written as-is (not escaped), so strip CR/LF to prevent a crafted
+    // value from injecting extra vCard properties or terminating the card.
+    private fun sanitizeUrl(value: String): String =
+        value.trim().replace("\r", "").replace("\n", "")
+
     private fun createVCard(
         contact: QrData.Contact,
         socialLinks: List<com.hereliesaz.qard.data.SocialLink>,
@@ -149,14 +154,14 @@ object QrGenerator {
             lines += "ADR${vcardType(it.label)}:;;${escapeVCard(it.value)};;;;"
         }
         contact.websites.filter { it.value.isNotBlank() }.forEach {
-            lines += "URL:${it.value.trim()}"
+            lines += "URL:${sanitizeUrl(it.value)}"
         }
-        links.filter { it.isNotBlank() }.forEach { lines += "URL:${it.trim()}" }
+        links.filter { it.isNotBlank() }.forEach { lines += "URL:${sanitizeUrl(it)}" }
 
         if (contact.birthday.isNotBlank()) lines += "BDAY:${escapeVCard(contact.birthday)}"
 
         socialLinks.filter { it.url.isNotBlank() }.forEach {
-            lines += "X-SOCIALPROFILE;TYPE=${escapeVCard(it.platform)}:${it.url}"
+            lines += "X-SOCIALPROFILE;TYPE=${escapeVCard(it.platform)}:${sanitizeUrl(it.url)}"
         }
 
         val noteParts = (listOf(contact.note) + contact.customFields

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
@@ -75,7 +75,7 @@ class QrWidget : GlanceAppWidget() {
                     }
 
                     if (dataIsNotBlank) {
-                        val qrBitmap = QrGenerator.generate(currentConfig)
+                        val qrBitmap = QrGenerator.generate(currentConfig)?.scaledForWidget()
                         if (qrBitmap != null) {
                             Image(
                                 provider = ImageProvider(qrBitmap),
@@ -97,5 +97,20 @@ class QrWidget : GlanceAppWidget() {
         val bitmap = createBitmap(1, 1)
         bitmap.eraseColor(0) // Makes the bitmap transparent
         return bitmap
+    }
+
+    // A widget's RemoteViews can't carry a multi-MB bitmap across the binder —
+    // the launcher then shows "can't show content". The generated QR can be
+    // 700px+ (several MB as ARGB), so cap it to a safe, still-scannable size.
+    private fun Bitmap.scaledForWidget(maxPx: Int = 384): Bitmap {
+        val largest = maxOf(width, height)
+        if (largest <= maxPx) return this
+        val scale = maxPx.toFloat() / largest
+        return Bitmap.createScaledBitmap(
+            this,
+            (width * scale).toInt().coerceAtLeast(1),
+            (height * scale).toInt().coerceAtLeast(1),
+            true
+        )
     }
 }

--- a/app/src/main/res/xml/qr_widget_info.xml
+++ b/app/src/main/res/xml/qr_widget_info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:configure="com.hereliesaz.qard.ui.ConfigActivity"
     android:description="@string/appwidget_description"
     android:initialLayout="@layout/widget_qr"
     android:minWidth="110dp"


### PR DESCRIPTION
## Summary by Sourcery

Migrate contact QR configurations from legacy single-value fields to the new structured contact fields, improve contact label handling and QR safety, and make widget QR rendering more robust.

Bug Fixes:
- Preserve and migrate legacy single-value contact fields (name, phone, email, website) into the structured contact model on load to avoid data loss.
- Prevent adding multiple empty labeled-value rows in the contact editor UI.
- Use Android contact type labels for imported phone, email, and postal addresses when reading contacts, falling back to generic labels when needed.
- Sanitize URLs used in vCard generation to strip CR/LF and prevent injection of additional properties.
- Scale large generated QR bitmaps down for widgets to avoid binder size issues and ensure the widget content can be displayed.