### PR TITLE
Load screen: highlight selected code + jump to Data on tap

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -484,8 +484,12 @@ fun ConfigScreen(
                         currentConfig = currentConfig,
                         onLoad = { cfg ->
                             loadSavedConfig(cfg)
-                            // Jump to Data so the repopulated fields are visible.
-                            navController.navigate("data")
+                            // Jump to Data so the repopulated fields are visible,
+                            // keeping the back stack clean.
+                            navController.navigate("data") {
+                                popUpTo("load")
+                                launchSingleTop = true
+                            }
                         }
                     )
                 }

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -479,7 +479,15 @@ fun ConfigScreen(
                 Box(modifier = Modifier.weight(1f)) {
                     AzNavHost(startDestination = "load") {
                 composable("load") {
-                    LoadScreen(dataStore = dataStore, updateConfig = loadSavedConfig)
+                    LoadScreen(
+                        dataStore = dataStore,
+                        currentConfig = currentConfig,
+                        onLoad = { cfg ->
+                            loadSavedConfig(cfg)
+                            // Jump to Data so the repopulated fields are visible.
+                            navController.navigate("data")
+                        }
+                    )
                 }
                 composable("data") {
                     DataScreen(currentConfig = currentConfig, updateConfig = updateConfig)
@@ -892,7 +900,8 @@ fun PresetsScreen(
 @Composable
 fun LoadScreen(
     dataStore: QrDataStore,
-    updateConfig: (QrConfig) -> Unit
+    currentConfig: QrConfig,
+    onLoad: (QrConfig) -> Unit
 ) {
     var savedConfigs by remember { mutableStateOf<List<QrConfig>>(emptyList()) }
     LaunchedEffect(key1 = Unit) {
@@ -921,7 +930,18 @@ fun LoadScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 gridItems(savedConfigs) { savedConfig ->
-                    Card(onClick = { updateConfig(savedConfig) }) {
+                    val isSelected = savedConfig == currentConfig
+                    Card(
+                        onClick = { onLoad(savedConfig) },
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (isSelected) {
+                                MaterialTheme.colorScheme.primaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            }
+                        ),
+                        border = if (isSelected) BorderStroke(2.dp, LogoPink) else null
+                    ) {
                         Box(modifier = Modifier.padding(8.dp)) {
                             QrCodePreview(config = savedConfig, title = null, imageSize = 96.dp)
                         }


### PR DESCRIPTION
## What

Tapping a saved QR code on the **Load** screen previously updated the editor's config silently while leaving you on the Load grid with no visual change — so it looked like nothing happened. Now tapping a saved code:

1. **Highlights** it (pink border + container tint, matching the shape-picker style), so the currently-loaded code is obvious.
2. **Navigates to the Data screen**, so the repopulated fields are immediately visible.

(The underlying load already set the config; this makes it visible and gives feedback.)

## Files
- `app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt`

> Not compiled locally (sandboxed Gradle) — CI builds both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Improve the Load screen interaction so selecting a saved QR configuration visibly highlights it and navigates to the Data screen.

New Features:
- Visually highlight the currently loaded QR configuration on the Load screen based on the active config.
- Navigate to the Data screen when a saved configuration is selected so repopulated fields are immediately visible.