### PR TITLE
Tap widget → action menu (open/scan, details, edit, open app)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,12 @@
             android:theme="@style/Theme.QaRd" />
 
         <activity
+            android:name=".ui.WidgetMenuActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <activity
             android:name=".ui.ConfigActivity"
             android:allowUntrustedActivityEmbedding="true"
             android:exported="true"

--- a/app/src/main/java/com/hereliesaz/qard/ui/WidgetMenuActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/WidgetMenuActivity.kt
@@ -1,0 +1,215 @@
+package com.hereliesaz.qard.ui
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.ContactsContract
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.hereliesaz.qard.data.QrConfig
+import com.hereliesaz.qard.data.QrData
+import com.hereliesaz.qard.data.QrDataStore
+import com.hereliesaz.qard.data.displayName
+import com.hereliesaz.qard.data.hasInfo
+import com.hereliesaz.qard.ui.theme.QaRdTheme
+import kotlinx.coroutines.flow.first
+
+/**
+ * The small menu shown when a home-screen widget is tapped. Offers acting on the
+ * code (like scanning it), viewing its details, editing it, or opening the app.
+ * Hosted in a translucent activity so it floats over the launcher.
+ */
+class WidgetMenuActivity : ComponentActivity() {
+
+    companion object {
+        fun intent(context: Context, appWidgetId: Int): Intent =
+            Intent(context, WidgetMenuActivity::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val appWidgetId = intent?.getIntExtra(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+        setContent {
+            QaRdTheme {
+                WidgetMenu(appWidgetId = appWidgetId, onClose = { finish() })
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetMenu(appWidgetId: Int, onClose: () -> Unit) {
+    val context = LocalContext.current
+    var config by remember { mutableStateOf<QrConfig?>(null) }
+    LaunchedEffect(appWidgetId) {
+        config = QrDataStore(context).getConfig(appWidgetId).first()
+    }
+
+    Dialog(onDismissRequest = onClose) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp),
+            ) {
+                Text(
+                    text = "QaRd",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+                )
+
+                val cfg = config
+                val primary = cfg?.let { primaryAction(it) }
+                if (primary != null) {
+                    MenuRow(Icons.Default.OpenInNew, primary.label) {
+                        primary.run(context)
+                        onClose()
+                    }
+                }
+                MenuRow(Icons.Default.Info, "View details") {
+                    context.startActivity(
+                        DetailActivity.widgetIntent(context, appWidgetId)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    )
+                    onClose()
+                }
+                MenuRow(Icons.Default.Edit, "Edit") {
+                    val intent = if (cfg != null) {
+                        ConfigActivity.standaloneIntent(context, cfg)
+                    } else {
+                        ConfigActivity.standaloneIntent(context)
+                    }
+                    context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                    onClose()
+                }
+                MenuRow(Icons.Default.Home, "Open QaRd app") {
+                    context.startActivity(
+                        Intent(context, MainActivity::class.java)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    )
+                    onClose()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MenuRow(icon: ImageVector, label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(imageVector = icon, contentDescription = null)
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+private class PrimaryAction(val label: String, val run: (Context) -> Unit)
+
+/** The "act on the code like a scanner would" action, derived from the config. */
+private fun primaryAction(config: QrConfig): PrimaryAction? {
+    val contact = config.data.filterIsInstance<QrData.Contact>().firstOrNull()?.takeIf { it.hasInfo() }
+    if (contact != null) {
+        return PrimaryAction("Add to contacts") { ctx -> openContactInsert(ctx, contact) }
+    }
+    val url = config.firstUrl()
+    if (url != null) {
+        return PrimaryAction("Open link") { ctx -> openUrl(ctx, url) }
+    }
+    return null
+}
+
+private fun QrConfig.firstUrl(): String? {
+    data.forEach { item ->
+        when (item) {
+            is QrData.Links -> item.links.firstOrNull { it.isNotBlank() }?.let { return it }
+            is QrData.SocialMedia -> item.links.firstOrNull { it.url.isNotBlank() }?.let { return it.url }
+            else -> {}
+        }
+    }
+    return null
+}
+
+private fun openUrl(context: Context, url: String) {
+    val normalized = if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+    try {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(normalized))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    } catch (e: Exception) {
+        // No handler / invalid URL — ignore.
+    }
+}
+
+private fun openContactInsert(context: Context, contact: QrData.Contact) {
+    val intent = Intent(ContactsContract.Intents.Insert.ACTION).apply {
+        type = ContactsContract.RawContacts.CONTENT_TYPE
+        putExtra(ContactsContract.Intents.Insert.NAME, contact.displayName())
+        contact.phones.firstOrNull { it.value.isNotBlank() }
+            ?.let { putExtra(ContactsContract.Intents.Insert.PHONE, it.value) }
+        contact.emails.firstOrNull { it.value.isNotBlank() }
+            ?.let { putExtra(ContactsContract.Intents.Insert.EMAIL, it.value) }
+        contact.addresses.firstOrNull { it.value.isNotBlank() }
+            ?.let { putExtra(ContactsContract.Intents.Insert.POSTAL, it.value) }
+        if (contact.organization.isNotBlank()) {
+            putExtra(ContactsContract.Intents.Insert.COMPANY, contact.organization)
+        }
+        if (contact.title.isNotBlank()) {
+            putExtra(ContactsContract.Intents.Insert.JOB_TITLE, contact.title)
+        }
+        if (contact.note.isNotBlank()) {
+            putExtra(ContactsContract.Intents.Insert.NOTES, contact.note)
+        }
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (e: Exception) {
+        // No contacts app — ignore.
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/widget/WidgetTapRouter.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/WidgetTapRouter.kt
@@ -2,85 +2,16 @@ package com.hereliesaz.qard.widget
 
 import android.appwidget.AppWidgetManager
 import android.content.Context
-import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
-import com.hereliesaz.qard.ui.ConfigActivity
-import com.hereliesaz.qard.ui.DetailActivity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
+import com.hereliesaz.qard.ui.WidgetMenuActivity
 
 /**
- * Routes taps on the home-screen widget into a single-tap or double-tap action.
- *
- * Home-screen widgets are [android.widget.RemoteViews]; they only receive click
- * callbacks (no raw touch stream), so a real [android.view.GestureDetector] is
- * impossible. Instead we count taps within a short window: the first tap arms a
- * delayed "single tap" job; a second tap inside [DOUBLE_TAP_WINDOW_MS] cancels
- * that job and fires the "double tap" action. This mirrors the multi-tap widget
- * approach used in the QuicLoc app.
- *
- *  - single tap -> open [DetailActivity] (see the info the code contains)
- *  - double tap -> open [ConfigActivity] (the construction screen) for the config
+ * Glance action invoked on every widget tap. Opens [WidgetMenuActivity], a small
+ * menu letting the user act on the code (like scanning it), view its details,
+ * edit it, or open the QaRd app.
  */
-object WidgetTapRouter {
-
-    private const val DOUBLE_TAP_WINDOW_MS = 280L
-
-    private val scope = CoroutineScope(SupervisorJob())
-
-    // Pending single-tap jobs keyed by appWidgetId.
-    private val pendingSingleTaps = mutableMapOf<Int, Job>()
-
-    fun onTap(context: Context, appWidgetId: Int) {
-        // Use the application context: this singleton scope outlives the
-        // short-lived receiver/widget context that delivered the tap.
-        val appContext = context.applicationContext
-        synchronized(pendingSingleTaps) {
-            val pending = pendingSingleTaps[appWidgetId]
-            if (pending != null && pending.isActive) {
-                // Second tap inside the window -> double tap.
-                pending.cancel()
-                pendingSingleTaps.remove(appWidgetId)
-                launchConstruction(appContext, appWidgetId)
-                return
-            }
-
-            // First tap -> arm a delayed single-tap action.
-            val job = scope.launch {
-                delay(DOUBLE_TAP_WINDOW_MS)
-                if (isActive) {
-                    launchDetail(appContext, appWidgetId)
-                    synchronized(pendingSingleTaps) { pendingSingleTaps.remove(appWidgetId) }
-                }
-            }
-            pendingSingleTaps[appWidgetId] = job
-        }
-    }
-
-    private fun launchDetail(context: Context, appWidgetId: Int) {
-        val intent = DetailActivity.widgetIntent(context, appWidgetId).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        context.startActivity(intent)
-    }
-
-    private fun launchConstruction(context: Context, appWidgetId: Int) {
-        val intent = Intent(context, ConfigActivity::class.java).apply {
-            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            putExtra(ConfigActivity.EXTRA_MODE, ConfigActivity.MODE_WIDGET_CONFIG)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        context.startActivity(intent)
-    }
-}
-
-/** Glance action invoked on every widget tap; delegates to [WidgetTapRouter]. */
 class WidgetTapAction : ActionCallback {
     override suspend fun onAction(
         context: Context,
@@ -91,7 +22,7 @@ class WidgetTapAction : ActionCallback {
             parameters[ActionParameters.Key<Int>(AppWidgetManager.EXTRA_APPWIDGET_ID)]
                 ?: AppWidgetManager.INVALID_APPWIDGET_ID
         if (appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
-            WidgetTapRouter.onTap(context, appWidgetId)
+            context.startActivity(WidgetMenuActivity.intent(context, appWidgetId))
         }
     }
 }


### PR DESCRIPTION
## What

Tapping a home-screen widget now opens a **small action menu** instead of the old single-tap (details) / double-tap (edit) gesture. The menu (a translucent `WidgetMenuActivity` floating over the launcher) offers:

- **Open link / Add to contacts** — acts on the code *like scanning it would*: opens the URL for a link/social code, or launches the contacts "add contact" screen (prefilled) for a contact code.
- **View details** — the existing detail screen.
- **Edit** — opens the editor with the widget's config.
- **Open QaRd app** — launches the app.

The primary action's label and behavior are derived from the code's content. `WidgetTapAction` now simply launches the menu (the old tap-counting router is gone).

## Files
- `ui/WidgetMenuActivity.kt` (new)
- `widget/WidgetTapRouter.kt` (simplified)
- `AndroidManifest.xml` (register the translucent activity)

> Not compiled locally (sandboxed Gradle) — CI builds both flavors. Best verified on a device.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Replace the widget tap router’s single/double‑tap behavior with a translucent widget action menu launched on every tap.

New Features:
- Show a floating WidgetMenuActivity when a home-screen widget is tapped, presenting actions relevant to the widget’s QR code.
- Derive a primary action from the QR content (open link or add to contacts) that behaves like scanning the code.
- Provide quick-access menu options to view QR details, edit the widget’s configuration, or open the main QaRd app.

Enhancements:
- Simplify widget tap handling by removing tap-counting logic and routing taps directly to the new menu activity.

Build:
- Register the new translucent WidgetMenuActivity in the Android manifest so it can be launched from widget taps.