### PR TITLE
Fix invisible widget + gate tap menu on loaded config

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/WidgetMenuActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/WidgetMenuActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -98,35 +100,44 @@ private fun WidgetMenu(appWidgetId: Int, onClose: () -> Unit) {
                 )
 
                 val cfg = config
-                val primary = cfg?.let { primaryAction(it) }
-                if (primary != null) {
-                    MenuRow(Icons.Default.OpenInNew, primary.label) {
-                        primary.run(context)
+                if (cfg == null) {
+                    // Config still loading — avoid acting on a null (blank) config.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                } else {
+                    primaryAction(cfg)?.let { primary ->
+                        MenuRow(Icons.Default.OpenInNew, primary.label) {
+                            primary.run(context)
+                            onClose()
+                        }
+                    }
+                    MenuRow(Icons.Default.Info, "View details") {
+                        context.startActivity(
+                            DetailActivity.widgetIntent(context, appWidgetId)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        )
                         onClose()
                     }
-                }
-                MenuRow(Icons.Default.Info, "View details") {
-                    context.startActivity(
-                        DetailActivity.widgetIntent(context, appWidgetId)
-                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    )
-                    onClose()
-                }
-                MenuRow(Icons.Default.Edit, "Edit") {
-                    val intent = if (cfg != null) {
-                        ConfigActivity.standaloneIntent(context, cfg)
-                    } else {
-                        ConfigActivity.standaloneIntent(context)
+                    MenuRow(Icons.Default.Edit, "Edit") {
+                        context.startActivity(
+                            ConfigActivity.standaloneIntent(context, cfg)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        )
+                        onClose()
                     }
-                    context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-                    onClose()
-                }
-                MenuRow(Icons.Default.Home, "Open QaRd app") {
-                    context.startActivity(
-                        Intent(context, MainActivity::class.java)
-                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    )
-                    onClose()
+                    MenuRow(Icons.Default.Home, "Open QaRd app") {
+                        context.startActivity(
+                            Intent(context, MainActivity::class.java)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        )
+                        onClose()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrWidget.kt
@@ -4,8 +4,6 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
 import androidx.glance.GlanceId
@@ -26,9 +24,11 @@ import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
+import com.hereliesaz.qard.data.QrConfig
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.data.QrDataStore
 import com.hereliesaz.qard.data.hasInfo
+import kotlinx.coroutines.flow.first
 
 class QrWidget : GlanceAppWidget() {
 
@@ -39,23 +39,25 @@ class QrWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val dataStore = QrDataStore(context)
         val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(id)
-        Log.d("WidgetFlow", "provideGlance for widget ID: $appWidgetId (from GlanceId $id)")
+
+        // Load the config up front (provideGlance is suspend). Doing it here rather
+        // than reactively inside provideContent guarantees the widget renders real
+        // content on its single composition — collectAsState's later emissions
+        // aren't reliably picked up by Glance, which left the tile blank/invisible.
+        val config = try {
+            dataStore.getConfig(appWidgetId).first()
+        } catch (e: Exception) {
+            Log.e("WidgetFlow", "Failed to load config for widget $appWidgetId", e)
+            QrConfig()
+        }
 
         provideContent {
-            val config by dataStore.getConfig(appWidgetId).collectAsState(initial = null)
-            Log.d("WidgetFlow", "Config received in widget (for ID $appWidgetId): $config")
-
-            // Every tap is routed through WidgetTapRouter, which distinguishes
-            // single tap (open detail) from double tap (open construction).
             val action = actionRunCallback<WidgetTapAction>(
                 parameters = actionParametersOf(
                     ActionParameters.Key<Int>(AppWidgetManager.EXTRA_APPWIDGET_ID) to appWidgetId
                 )
             )
 
-            // Always emit a root Box so Glance never renders empty ("can't load
-            // widget"); while config is still loading the box stays blank, which
-            // avoids flashing the "Tap to configure" placeholder on every update.
             Box(
                 modifier = GlanceModifier
                     .fillMaxSize()
@@ -64,30 +66,27 @@ class QrWidget : GlanceAppWidget() {
                     .clickable(action),
                 contentAlignment = Alignment.Center
             ) {
-                val currentConfig = config
-                if (currentConfig != null) {
-                    val dataIsNotBlank = currentConfig.data.any {
-                        when (it) {
-                            is QrData.Links -> it.links.any { link -> link.isNotBlank() }
-                            is QrData.Contact -> it.hasInfo()
-                            is QrData.SocialMedia -> it.links.any { social -> social.url.isNotBlank() }
-                        }
+                val dataIsNotBlank = config.data.any {
+                    when (it) {
+                        is QrData.Links -> it.links.any { link -> link.isNotBlank() }
+                        is QrData.Contact -> it.hasInfo()
+                        is QrData.SocialMedia -> it.links.any { social -> social.url.isNotBlank() }
                     }
+                }
 
-                    if (dataIsNotBlank) {
-                        val qrBitmap = QrGenerator.generate(currentConfig)?.scaledForWidget()
-                        if (qrBitmap != null) {
-                            Image(
-                                provider = ImageProvider(qrBitmap),
-                                contentDescription = "User-defined QR Code",
-                                modifier = GlanceModifier.fillMaxSize()
-                            )
-                        } else {
-                            Text("Error generating QR Code.")
-                        }
+                if (dataIsNotBlank) {
+                    val qrBitmap = QrGenerator.generate(config)?.scaledForWidget()
+                    if (qrBitmap != null) {
+                        Image(
+                            provider = ImageProvider(qrBitmap),
+                            contentDescription = "User-defined QR Code",
+                            modifier = GlanceModifier.fillMaxSize()
+                        )
                     } else {
-                        Text("Tap to configure")
+                        Text("Error generating QR Code.")
                     }
+                } else {
+                    Text("Tap to configure")
                 }
             }
         }


### PR DESCRIPTION
## What

Two widget fixes:

### 1. Fix the widget not appearing (regression)
`QrWidget` loaded its config reactively via `collectAsState(initial = null)` and gated **all** content on `config != null`. A Glance widget composes ~once per update and doesn't reliably pick up later flow emissions, so the first (null) frame rendered an **empty, transparent tile** that never updated — the widget looked like it wasn't there. Now the config is loaded **synchronously in `provideGlance`** (a `suspend` fun) and the content renders from it, so the tile always shows the QR (or the "Tap to configure" placeholder for an unconfigured one).

### 2. Gate the tap menu on the loaded config
The widget tap menu showed a spinner-less menu while its config was still loading, so tapping **Edit** could open a blank editor. Now it shows a spinner until the config loads, then the options.

## Files
- `widget/QrWidget.kt`
- `ui/WidgetMenuActivity.kt`

> Not compiled locally (sandboxed Gradle) — CI builds both flavors. Best verified on a device.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

## Summary by Sourcery

Ensure the QR widget and its tap menu reliably use a loaded configuration so the widget is visible and interactions are valid.

Bug Fixes:
- Fix QR widget sometimes rendering as an invisible, empty tile by loading its configuration synchronously when providing Glance content.
- Prevent the widget tap menu from showing interactive options while configuration is still loading by displaying a loading indicator until config is available.