### PR TITLE
Allow the widget to resize to full launcher width

### DIFF
--- a/app/src/main/res/xml/qr_widget_info.xml
+++ b/app/src/main/res/xml/qr_widget_info.xml
@@ -8,8 +8,6 @@
     android:minResizeHeight="40dp"
     android:targetCellWidth="2"
     android:targetCellHeight="2"
-    android:maxResizeWidth="640dp"
-    android:maxResizeHeight="640dp"
     android:previewImage="@mipmap/ic_launcher"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="86400000"


### PR DESCRIPTION
## What

The widget capped at ~4/5 of the screen because `maxResizeWidth/maxResizeHeight` was `640dp`. Removing those caps lets the launcher resize it up to its full grid (full width). `resizeMode="horizontal|vertical"` stays, so long-press resize remains enabled.

## Files
- `app/src/main/res/xml/qr_widget_info.xml`

> Note: an app can't programmatically resize its own placed widget (launcher-owned); `resizeMode` is what enables the user's long-press resize. This change removes the size ceiling so it can reach full width.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Enhancements:
- Allow the QR widget to resize without a fixed maximum width or height cap, enabling full-width launcher layouts.