### PR TITLE
Load screen: long-press to delete a saved code (with confirmation)

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 
@@ -82,6 +83,12 @@ class QrDataStore(private val context: Context) {
         context.dataStore.edit { preferences ->
             preferences[SAVED_CONFIGS_KEY] = json.encodeToString(configs)
         }
+    }
+
+    /** Removes a config from the saved-configs list. */
+    suspend fun deleteSavedConfig(config: QrConfig) {
+        val current = getSavedConfigs().first()
+        saveConfigs(current.filterNot { it == config })
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrDataStore.kt
@@ -8,7 +8,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 
@@ -85,10 +84,20 @@ class QrDataStore(private val context: Context) {
         }
     }
 
-    /** Removes a config from the saved-configs list. */
+    /** Removes a config from the saved-configs list (atomic read-modify-write). */
     suspend fun deleteSavedConfig(config: QrConfig) {
-        val current = getSavedConfigs().first()
-        saveConfigs(current.filterNot { it == config })
+        context.dataStore.edit { preferences ->
+            val jsonString = preferences[SAVED_CONFIGS_KEY] ?: return@edit
+            val updated = try {
+                // Migrate so a legacy-shaped stored entry still matches the migrated UI config.
+                json.decodeFromString<List<QrConfig>>(jsonString)
+                    .map { it.migrated() }
+                    .filterNot { it == config }
+            } catch (e: Exception) {
+                return@edit
+            }
+            preferences[SAVED_CONFIGS_KEY] = json.encodeToString(updated)
+        }
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -85,6 +85,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
@@ -950,10 +951,12 @@ fun LoadScreen(
                             }
                         ),
                         border = if (isSelected) BorderStroke(2.dp, LogoPink) else null,
-                        modifier = Modifier.combinedClickable(
-                            onClick = { onLoad(savedConfig) },
-                            onLongClick = { pendingDelete = savedConfig }
-                        )
+                        modifier = Modifier
+                            .clip(CardDefaults.shape)
+                            .combinedClickable(
+                                onClick = { onLoad(savedConfig) },
+                                onLongClick = { pendingDelete = savedConfig }
+                            )
                     ) {
                         Box(modifier = Modifier.padding(8.dp)) {
                             QrCodePreview(config = savedConfig, title = null, imageSize = 96.dp)

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -19,8 +19,10 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -73,6 +75,7 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -901,13 +904,16 @@ fun PresetsScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LoadScreen(
     dataStore: QrDataStore,
     currentConfig: QrConfig,
     onLoad: (QrConfig) -> Unit
 ) {
+    val scope = rememberCoroutineScope()
     var savedConfigs by remember { mutableStateOf<List<QrConfig>>(emptyList()) }
+    var pendingDelete by remember { mutableStateOf<QrConfig?>(null) }
     LaunchedEffect(key1 = Unit) {
         dataStore.getSavedConfigs().collect { savedConfigs = it }
     }
@@ -924,7 +930,7 @@ fun LoadScreen(
             )
         } else {
             Text(
-                "Tap a saved QR Code to load it into the editor.",
+                "Tap a saved QR Code to load it; long-press to delete.",
                 style = MaterialTheme.typography.bodyMedium
             )
             LazyVerticalGrid(
@@ -936,7 +942,6 @@ fun LoadScreen(
                 gridItems(savedConfigs) { savedConfig ->
                     val isSelected = savedConfig == currentConfig
                     Card(
-                        onClick = { onLoad(savedConfig) },
                         colors = CardDefaults.cardColors(
                             containerColor = if (isSelected) {
                                 MaterialTheme.colorScheme.primaryContainer
@@ -944,7 +949,11 @@ fun LoadScreen(
                                 MaterialTheme.colorScheme.surfaceVariant
                             }
                         ),
-                        border = if (isSelected) BorderStroke(2.dp, LogoPink) else null
+                        border = if (isSelected) BorderStroke(2.dp, LogoPink) else null,
+                        modifier = Modifier.combinedClickable(
+                            onClick = { onLoad(savedConfig) },
+                            onLongClick = { pendingDelete = savedConfig }
+                        )
                     ) {
                         Box(modifier = Modifier.padding(8.dp)) {
                             QrCodePreview(config = savedConfig, title = null, imageSize = 96.dp)
@@ -953,6 +962,27 @@ fun LoadScreen(
                 }
             }
         }
+    }
+
+    pendingDelete?.let { target ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete saved code?") },
+            text = { Text("This removes it from your saved codes and can't be undone.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    scope.launch { dataStore.deleteSavedConfig(target) }
+                    pendingDelete = null
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## What

On the **Load** screen, **long-pressing** a saved QR preview now prompts a confirmation dialog ("Delete saved code?") and, on confirm, removes it from the saved list. A normal **tap** still loads the code into the editor.

- `QrDataStore.deleteSavedConfig(config)` removes the entry from the saved-configs list; the Load grid updates live (it collects the saved-configs flow).
- The card uses `combinedClickable` (tap = load, long-press = delete prompt).

## Files
- `ui/ConfigActivity.kt` (LoadScreen)
- `data/QrDataStore.kt`

> Not compiled locally (sandboxed Gradle) — CI builds both flavors.

https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7fEbUxV7TFDZeUxcDZkYZ)_

## Summary by Sourcery

Add long-press deletion with confirmation for saved QR codes on the Load screen and persist deletions in the saved-configs datastore.

New Features:
- Support long-press on saved QR cards in the Load screen to trigger a delete confirmation dialog.
- Add datastore support for removing a QR configuration from the saved-configs list.

Enhancements:
- Update Load screen helper text to describe both tap-to-load and long-press-to-delete interactions.