### PR TITLE
Sender-only file transfer (Phase 0+1): same-Wi-Fi hand-off

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,9 @@ dependencies {
     // Menu
     implementation(libs.aznavrail)
 
+    // Local HTTP server for same-Wi-Fi file hand-off (sender side).
+    implementation(libs.nanohttpd)
+
     // Google AdMob — play flavor only, so the foss build pulls in no ad SDK.
     "playImplementation"(libs.play.services.ads)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,12 @@
     <!-- Lets the user import a contact (incl. Google-synced ones) into a Contact QR. -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 
+    <!-- Same-Wi-Fi file hand-off: open a local socket and read the device's LAN IP so a
+         receiver can fetch the file from a QR'd URL using their stock camera. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
     <application
         android:name=".QaRdApp"
         android:allowBackup="true"
@@ -37,6 +43,12 @@
         <activity
             android:name=".ui.DetailActivity"
             android:exported="false"
+            android:theme="@style/Theme.QaRd" />
+
+        <activity
+            android:name=".ui.SendFileActivity"
+            android:exported="false"
+            android:label="Send a file"
             android:theme="@style/Theme.QaRd" />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
             android:name=".ui.SendFileActivity"
             android:exported="false"
             android:label="Send a file"
+            android:configChanges="orientation|screenSize|keyboardHidden"
             android:theme="@style/Theme.QaRd" />
 
         <activity

--- a/app/src/main/java/com/hereliesaz/qard/transfer/LocalFileServer.kt
+++ b/app/src/main/java/com/hereliesaz/qard/transfer/LocalFileServer.kt
@@ -1,0 +1,65 @@
+package com.hereliesaz.qard.transfer
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import fi.iki.elonen.NanoHTTPD
+import java.util.UUID
+
+/**
+ * A tiny one-file HTTP server for same-Wi-Fi hand-off. The sender shows a QR with this
+ * server's URL; a receiver on the same network opens it with their stock camera and the
+ * browser downloads the file directly — no app needed on the receiving end.
+ *
+ * Security model for a browser receiver (which can't run any client-side decryption): the
+ * file is served as-is behind an unguessable [token] path, so only someone who scanned the
+ * QR can fetch it, and only while the server is running. Bind on port 0 for an ephemeral
+ * port; read [listeningPort] after [start].
+ */
+class LocalFileServer(
+    private val appContext: Context,
+    private val fileUri: Uri,
+    private val fileName: String,
+    private val mimeType: String,
+    private val fileSize: Long,
+    port: Int = 0,
+) : NanoHTTPD(port) {
+
+    /** Unguessable path segment included in the QR'd URL. */
+    val token: String = UUID.randomUUID().toString().replace("-", "")
+
+    private val downloadPath = "/d/$token"
+
+    override fun serve(session: IHTTPSession): Response {
+        if (session.method != Method.GET || session.uri != downloadPath) {
+            return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Not found")
+        }
+        val input = try {
+            appContext.contentResolver.openInputStream(fileUri)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to open file for serving", e)
+            null
+        } ?: return newFixedLengthResponse(
+            Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Cannot read file"
+        )
+
+        val response = if (fileSize >= 0) {
+            newFixedLengthResponse(Response.Status.OK, mimeType, input, fileSize)
+        } else {
+            newChunkedResponse(Response.Status.OK, mimeType, input)
+        }
+        response.addHeader("Content-Disposition", "attachment; filename=\"${sanitize(fileName)}\"")
+        return response
+    }
+
+    /** The URL a receiver opens, e.g. `http://192.168.1.5:43215/d/<token>`. */
+    fun url(host: String): String = "http://$host:$listeningPort$downloadPath"
+
+    // Strip characters that could break out of the Content-Disposition header.
+    private fun sanitize(name: String): String =
+        name.replace("\"", "").replace("\r", "").replace("\n", "")
+
+    companion object {
+        private const val TAG = "LocalFileServer"
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/transfer/LocalFileServer.kt
+++ b/app/src/main/java/com/hereliesaz/qard/transfer/LocalFileServer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import fi.iki.elonen.NanoHTTPD
+import java.net.URLEncoder
 import java.util.UUID
 
 /**
@@ -48,7 +49,13 @@ class LocalFileServer(
         } else {
             newChunkedResponse(Response.Status.OK, mimeType, input)
         }
-        response.addHeader("Content-Disposition", "attachment; filename=\"${sanitize(fileName)}\"")
+        // RFC 5987 filename* carries non-ASCII names (accents, CJK, emoji) intact; the
+        // plain filename is the ASCII-safe fallback for older clients.
+        val encoded = URLEncoder.encode(fileName, "UTF-8").replace("+", "%20")
+        response.addHeader(
+            "Content-Disposition",
+            "attachment; filename=\"${sanitize(fileName)}\"; filename*=UTF-8''$encoded"
+        )
         return response
     }
 

--- a/app/src/main/java/com/hereliesaz/qard/transfer/NetworkUtils.kt
+++ b/app/src/main/java/com/hereliesaz/qard/transfer/NetworkUtils.kt
@@ -1,8 +1,5 @@
 package com.hereliesaz.qard.transfer
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.util.Log
 import java.net.Inet4Address
 import java.net.NetworkInterface
@@ -18,7 +15,8 @@ object NetworkUtils {
      */
     fun localIpAddress(): String? {
         return try {
-            Collections.list(NetworkInterface.getNetworkInterfaces())
+            val interfaces = NetworkInterface.getNetworkInterfaces() ?: return null
+            Collections.list(interfaces)
                 .asSequence()
                 .filter { runCatching { it.isUp && !it.isLoopback }.getOrDefault(false) }
                 .flatMap { Collections.list(it.inetAddresses).asSequence() }
@@ -29,14 +27,5 @@ object NetworkUtils {
             Log.e("NetworkUtils", "Failed to read local IP", e)
             null
         }
-    }
-
-    /** Whether the device is currently on a Wi-Fi network (best-effort). */
-    fun isOnWifi(context: Context): Boolean {
-        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-            ?: return false
-        val network = cm.activeNetwork ?: return false
-        val caps = cm.getNetworkCapabilities(network) ?: return false
-        return caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
     }
 }

--- a/app/src/main/java/com/hereliesaz/qard/transfer/NetworkUtils.kt
+++ b/app/src/main/java/com/hereliesaz/qard/transfer/NetworkUtils.kt
@@ -1,0 +1,42 @@
+package com.hereliesaz.qard.transfer
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.util.Log
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.util.Collections
+
+/** Helpers for locating this device on the local network for same-Wi-Fi transfers. */
+object NetworkUtils {
+
+    /**
+     * The device's site-local IPv4 address (e.g. 192.168.x.x / 10.x.x.x) on the active
+     * Wi-Fi or hotspot interface, or null if none is found. This is the address a
+     * receiver on the same network uses to reach our local file server.
+     */
+    fun localIpAddress(): String? {
+        return try {
+            Collections.list(NetworkInterface.getNetworkInterfaces())
+                .asSequence()
+                .filter { runCatching { it.isUp && !it.isLoopback }.getOrDefault(false) }
+                .flatMap { Collections.list(it.inetAddresses).asSequence() }
+                .filterIsInstance<Inet4Address>()
+                .firstOrNull { !it.isLoopbackAddress && it.isSiteLocalAddress }
+                ?.hostAddress
+        } catch (e: Exception) {
+            Log.e("NetworkUtils", "Failed to read local IP", e)
+            null
+        }
+    }
+
+    /** Whether the device is currently on a Wi-Fi network (best-effort). */
+    fun isOnWifi(context: Context): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return false
+        val network = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(network) ?: return false
+        return caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -54,6 +54,7 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
@@ -477,6 +478,15 @@ fun ConfigScreen(
         azRailItem(id = "design", text = "Design", route = "design", content = Icons.Default.Palette, color = Color.White, textColor = Color.White)
         azRailItem(id = "preview", text = "Preview", route = "preview", content = Icons.Default.Visibility, color = Color.White, textColor = Color.White)
         azRailItem(id = "save", text = "Save", route = "save", content = Icons.Default.Save, color = Color.White, textColor = Color.White)
+        // Launches the standalone "pass a file on" flow (same-Wi-Fi hand-off).
+        azRailItem(
+            id = "send",
+            text = "Send",
+            content = Icons.Default.Send,
+            color = Color.White,
+            textColor = Color.White,
+            onClick = { context.startActivity(Intent(context, SendFileActivity::class.java)) }
+        )
 
         onscreen {
             Column(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/hereliesaz/qard/ui/SendFileActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/SendFileActivity.kt
@@ -1,0 +1,233 @@
+package com.hereliesaz.qard.ui
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.provider.OpenableColumns
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.qard.data.QrConfig
+import com.hereliesaz.qard.data.QrData
+import com.hereliesaz.qard.transfer.LocalFileServer
+import com.hereliesaz.qard.transfer.NetworkUtils
+import com.hereliesaz.qard.ui.theme.QaRdTheme
+import com.hereliesaz.qard.widget.QrGenerator
+import java.util.Locale
+
+/**
+ * Sender-only "pass it on" screen for files. Phase 1: same-Wi-Fi hand-off — pick a file,
+ * serve it from a local HTTP server, and show a QR of the URL. The receiver scans it with
+ * their stock camera; no app, no scanner, no account needed on the other end.
+ */
+class SendFileActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            QaRdTheme {
+                SendFileScreen()
+            }
+        }
+    }
+}
+
+private sealed interface SendState {
+    data object Idle : SendState
+    data object NoNetwork : SendState
+    data class Error(val message: String) : SendState
+    data class Serving(
+        val url: String,
+        val fileName: String,
+        val fileSize: Long,
+    ) : SendState
+}
+
+@Composable
+fun SendFileScreen() {
+    val context = LocalContext.current
+    var state by remember { mutableStateOf<SendState>(SendState.Idle) }
+    var server by remember { mutableStateOf<LocalFileServer?>(null) }
+
+    fun stopServer() {
+        server?.let { runCatching { it.stop() } }
+        server = null
+    }
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        stopServer()
+
+        val ip = NetworkUtils.localIpAddress()
+        if (ip == null) {
+            state = SendState.NoNetwork
+            return@rememberLauncherForActivityResult
+        }
+
+        val meta = queryFile(context, uri)
+        val srv = LocalFileServer(
+            appContext = context.applicationContext,
+            fileUri = uri,
+            fileName = meta.name,
+            mimeType = context.contentResolver.getType(uri) ?: "application/octet-stream",
+            fileSize = meta.size,
+        )
+        try {
+            srv.start(NanoHttpdTimeoutMs, false)
+        } catch (e: Exception) {
+            Log.e("SendFileActivity", "Failed to start local server", e)
+            state = SendState.Error("Couldn't start the local server. Try again.")
+            return@rememberLauncherForActivityResult
+        }
+        server = srv
+        state = SendState.Serving(srv.url(ip), meta.name, meta.size)
+    }
+
+    // Tear the server down when the screen leaves composition.
+    DisposableEffect(Unit) {
+        onDispose { stopServer() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        when (val s = state) {
+            is SendState.Idle -> {
+                Text(
+                    "Send a file to a nearby phone on the same Wi-Fi. Pick a file and a QR " +
+                        "appears — the other person scans it with their normal camera and the " +
+                        "file downloads in their browser. No app needed on their end.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            is SendState.NoNetwork -> {
+                Text(
+                    "You're not on a Wi-Fi network. Connect both phones to the same Wi-Fi, " +
+                        "then try again.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            is SendState.Error -> {
+                Text(
+                    s.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            is SendState.Serving -> {
+                val bitmap = remember(s.url) {
+                    QrGenerator.generate(
+                        QrConfig(data = listOf(QrData.Links(links = listOf(s.url))))
+                    )
+                }
+                if (bitmap != null) {
+                    Image(
+                        bitmap = bitmap.asImageBitmap(),
+                        contentDescription = "QR code for the file download link",
+                        modifier = Modifier.size(280.dp),
+                    )
+                }
+                Text(
+                    s.fileName,
+                    style = MaterialTheme.typography.titleMedium,
+                    textAlign = TextAlign.Center,
+                )
+                if (s.fileSize >= 0) {
+                    Text(
+                        formatSize(s.fileSize),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Text(
+                    "Have them scan this with their camera while you stay on this screen. " +
+                        "The link stops working when you leave.",
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    s.url,
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+
+        Button(
+            onClick = { picker.launch(arrayOf("*/*")) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (state is SendState.Serving) "Pick another file" else "Choose a file")
+        }
+    }
+}
+
+private data class FileMeta(val name: String, val size: Long)
+
+/** Reads the display name and size of a SAF document Uri. Size is -1 if unknown. */
+private fun queryFile(context: Context, uri: Uri): FileMeta {
+    var name = "file"
+    var size = -1L
+    runCatching {
+        context.contentResolver.query(uri, null, null, null, null)?.use { c ->
+            val nameIdx = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            val sizeIdx = c.getColumnIndex(OpenableColumns.SIZE)
+            if (c.moveToFirst()) {
+                if (nameIdx >= 0) c.getString(nameIdx)?.let { name = it }
+                if (sizeIdx >= 0 && !c.isNull(sizeIdx)) size = c.getLong(sizeIdx)
+            }
+        }
+    }
+    return FileMeta(name, size)
+}
+
+private fun formatSize(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val units = listOf("KB", "MB", "GB", "TB")
+    var value = bytes.toDouble() / 1024
+    var unitIndex = 0
+    while (value >= 1024 && unitIndex < units.lastIndex) {
+        value /= 1024
+        unitIndex++
+    }
+    return String.format(Locale.US, "%.1f %s", value, units[unitIndex])
+}
+
+// NanoHTTPD socket read timeout (ms); generous so a slow download isn't dropped.
+private const val NanoHttpdTimeoutMs = 60_000

--- a/app/src/main/java/com/hereliesaz/qard/ui/SendFileActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/SendFileActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.text.format.Formatter
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -39,7 +40,6 @@ import com.hereliesaz.qard.transfer.LocalFileServer
 import com.hereliesaz.qard.transfer.NetworkUtils
 import com.hereliesaz.qard.ui.theme.QaRdTheme
 import com.hereliesaz.qard.widget.QrGenerator
-import java.util.Locale
 
 /**
  * Sender-only "pass it on" screen for files. Phase 1: same-Wi-Fi hand-off — pick a file,
@@ -171,7 +171,7 @@ fun SendFileScreen() {
                 )
                 if (s.fileSize >= 0) {
                     Text(
-                        formatSize(s.fileSize),
+                        Formatter.formatFileSize(context, s.fileSize),
                         style = MaterialTheme.typography.bodySmall,
                     )
                 }
@@ -215,18 +215,6 @@ private fun queryFile(context: Context, uri: Uri): FileMeta {
         }
     }
     return FileMeta(name, size)
-}
-
-private fun formatSize(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
-    val units = listOf("KB", "MB", "GB", "TB")
-    var value = bytes.toDouble() / 1024
-    var unitIndex = 0
-    while (value >= 1024 && unitIndex < units.lastIndex) {
-        value /= 1024
-        unitIndex++
-    }
-    return String.format(Locale.US, "%.1f %s", value, units[unitIndex])
 }
 
 // NanoHTTPD socket read timeout (ms); generous so a slow download isn't dropped.

--- a/docs/file-transfer.md
+++ b/docs/file-transfer.md
@@ -1,0 +1,70 @@
+# Pass it on — file transfer design
+
+QaRd is a **sender-only** "pass something on FAST" app: a link, a vCard, social
+profiles, or a file. Everything the *receiver* touches is a single static QR opened with
+their **stock phone camera** — no second app, no scanner, no account on the other end.
+
+## Why a QR can't carry the file
+
+A QR code holds ~3 KB at best, and even animated/streaming QR over standard codes tops out
+around 10–30 kbps and *requires a custom receiver app* to film and reassemble the frames.
+Since we want stock-camera receivers, anything that needs a custom receiver is out. So:
+
+- **Link / vCard / social / text** → encoded directly in the QR (existing behaviour).
+- **File** → the QR carries a **URL**; the app hosts the bytes and the receiver's browser
+  downloads them.
+
+## Routing a file: local when shared, cloud otherwise
+
+| Case | Transport | Notes |
+| --- | --- | --- |
+| Both phones on the same Wi-Fi | In-app HTTP server, QR = `http://<ip>:<port>/d/<token>` | Fast, private, offline, free. |
+| Not the same network | Upload to Cloudflare R2, QR = `https://…/d/<id>` | Works on any receiver network; needs sender data. |
+
+Selection: try local (a site-local Wi-Fi IP is available) and fall back to cloud.
+
+## Security model
+
+The receiver is a stock browser, which **can't run any client-side decryption**, so the
+server must return the real file. Confidentiality therefore rests on:
+
+- an **unguessable token** in the URL path,
+- the server only running **while the sender stays on the screen** (local), or a short
+  **TTL** on the object (cloud),
+- **HTTPS** for the cloud path.
+
+(Client-side AES with the key in the QR was considered and rejected — it only works if our
+own app is the receiver, which contradicts the stock-camera goal.)
+
+## Cloudflare R2 + Worker (cloud path)
+
+- `POST /new` → Worker returns a presigned R2 upload URL + a short download id; the client
+  PUTs the file straight to R2.
+- `GET /d/:id` → Worker streams the object back (or 302s to a presigned GET).
+- An R2 lifecycle rule auto-deletes objects after the TTL; the Worker refuses expired ids.
+
+Deploying this needs the repo owner's Cloudflare account (R2 bucket, Worker, API token);
+the client code only does plain HTTPS upload/download, so it stays foss-clean.
+
+## Phasing
+
+- **Phase 0 (done):** Send flow + SAF file pick. *(No scanner anywhere.)*
+- **Phase 1 (done):** Local-Wi-Fi serving + URL QR. `LocalFileServer` (NanoHTTPD) +
+  `NetworkUtils` + `SendFileActivity`/`SendFileScreen`, launched from the editor's "Send"
+  rail item. No backend; ships standalone.
+- **Phase 2:** Cloudflare R2 relay (upload + short-link QR + expiry).
+- **Phase 3:** Auto local/cloud selection + polish — foreground service so the local
+  server survives backgrounding, retries, "link expires in…", progress.
+
+## Components (Phase 1)
+
+- `transfer/LocalFileServer.kt` — one-file NanoHTTPD server behind an unguessable token.
+- `transfer/NetworkUtils.kt` — site-local IPv4 + Wi-Fi check.
+- `ui/SendFileActivity.kt` — pick a file → start the server → show the URL QR.
+
+## Known limitations (Phase 1)
+
+- Same-Wi-Fi only (cloud relay is Phase 2).
+- The server is tied to the Activity lifecycle; leaving the screen stops it. A foreground
+  service (Phase 3) is needed for background-safe transfers of large files.
+- No transfer progress UI yet.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ appcompat = "1.7.0"
 constraintlayout = "2.2.0"
 navigationCompose = "2.8.4"
 playServicesAds = "23.6.0"
+nanohttpd = "2.3.1"
 
 [libraries]
 # Core & UI
@@ -57,6 +58,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 qrcode-kotlin-android = { module = "io.github.g0dkar:qrcode-kotlin-android", version.ref = "qrcodeKotlinAndroid" }
+nanohttpd = { module = "org.nanohttpd:nanohttpd", version.ref = "nanohttpd" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
 [plugins]


### PR DESCRIPTION
## What

"Pass a file on FAST" — sender-only, **no app needed on the receiving end**. Pick a file → the app serves it from a tiny local HTTP server → it shows a QR of the URL → the other phone scans it with its **stock camera** and the browser downloads the file.

This is **Phase 0 + Phase 1** of the agreed design (`docs/file-transfer.md`): same-Wi-Fi only, no backend. Cloud relay (Cloudflare R2) and a background foreground-service are later phases.

## Why this shape
A QR can't carry a file (~3 KB cap), and animated/streaming QR needs a *custom receiver app* — which contradicts "stock camera on the other end." So a file becomes a **URL** that the app hosts. Links/vCards/social already fit *in* the QR (existing behavior); only files need hosting.

## How it routes (this PR)
- Same Wi-Fi → in-app HTTP server, QR = `http://<ip>:<port>/d/<token>`.
- (Phase 2, not here) not same network → Cloudflare R2 + short `https://` link.

## Security model
The receiver is a stock browser and **can't run client-side decryption**, so the server returns the real file. Confidentiality rests on an **unguessable token** in the path + the server only running **while the sender stays on the screen**. (Client-side AES with the key in the QR was rejected — it only works if our own app is the receiver.)

## Files
- `transfer/LocalFileServer.kt` — one-file NanoHTTPD server behind an unguessable token.
- `transfer/NetworkUtils.kt` — site-local IPv4 + Wi-Fi check.
- `ui/SendFileActivity.kt` — SAF pick → serve → URL QR; server tied to the Activity lifecycle.
- `ConfigActivity.kt` — a **Send** rail item launches it.
- New dep: `org.nanohttpd:nanohttpd:2.3.1` (foss-clean, no Google deps). Permissions: `INTERNET`, `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE`.

## Known limitations (by phase)
- Same-Wi-Fi only (cloud relay = Phase 2).
- Server lives with the Activity; leaving the screen stops it (foreground service = Phase 3).
- No transfer-progress UI yet.

## Notes
- Independent of PR #61.
- Couldn't compile in the CI environment (the `foojay-resolver` Gradle plugin isn't cached and the network policy blocks resolving it) — please do a local build. NanoHTTPD API usage verified against 2.3.1.

https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G)_

## Summary by Sourcery

Introduce a sender-only, same-Wi-Fi file hand-off flow that serves a selected file over a local HTTP server and exposes it via a QR-coded URL.

New Features:
- Add a Send screen and activity that let users pick a file, start a local HTTP server for it, and show a QR code for the download URL to nearby devices on the same Wi-Fi.

Enhancements:
- Add utilities to discover the device's local IPv4 address for use in same-network file transfers.
- Introduce a lightweight local HTTP file server that exposes a single file behind an unguessable tokenized path for ad-hoc transfers.

Build:
- Add the NanoHTTPD dependency to provide the in-app HTTP server used for local file transfer.
- Declare network-related permissions and register the new SendFileActivity in the Android manifest to support local file serving.

Documentation:
- Document the end-to-end file transfer design, phases, and security model for QR-based, sender-only file sharing.