### PR TITLE
Render AzNavRail items as text labels (remove icon content)

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -475,10 +475,6 @@ fun ConfigScreen(
         // content-less Help item already does). Text labels are what we want here.
         azRailItem(id = "load", text = "Load", route = "load", textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
         azRailItem(id = "data", text = "Data", route = "data", textColor = Color.White, info = "Pick what the code carries — a link, a contact card, or social profiles — and fill in the details.")
-        azRailItem(id = "presets", text = "Presets", route = "presets", textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
-        azRailItem(id = "design", text = "Design", route = "design", textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
-        azRailItem(id = "preview", text = "Preview", route = "preview", textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
-        azRailItem(id = "save", text = "Save", route = "save", textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
         // Launches the standalone "pass a file on" flow (same-Wi-Fi hand-off).
         azRailItem(
             id = "send",
@@ -487,6 +483,10 @@ fun ConfigScreen(
             info = "Hand a file to a nearby phone on the same Wi-Fi; they scan the QR with their camera to download it.",
             onClick = { context.startActivity(Intent(context, SendFileActivity::class.java)) }
         )
+        azRailItem(id = "presets", text = "Presets", route = "presets", textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
+        azRailItem(id = "design", text = "Design", route = "design", textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
+        azRailItem(id = "preview", text = "Preview", route = "preview", textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
+        azRailItem(id = "save", text = "Save", route = "save", textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
         azHelpRailItem(id = "help", text = "Help", textColor = Color.White)
 
 

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -42,21 +42,14 @@ import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.CropSquare
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Link
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -477,19 +470,21 @@ fun ConfigScreen(
         // Enable AzNavRail's help overlay: tapping the Help rail item draws info cards
         // linked to each rail item, sourced from the `info` text below.
         azAdvanced(helpEnabled = true)
-        azRailItem(id = "load", text = "Load", route = "load", content = Icons.Default.FolderOpen, textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
-        azRailItem(id = "data", text = "Data", route = "data", content = Icons.Default.Edit, textColor = Color.White, info = "Pick what the code carries — a link, a contact card, or social profiles — and fill in the details.")
-        azRailItem(id = "presets", text = "Presets", route = "presets", content = Icons.Default.AutoAwesome, textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
-        azRailItem(id = "design", text = "Design", route = "design", content = Icons.Default.Palette, textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
-        azRailItem(id = "preview", text = "Preview", route = "preview", content = Icons.Default.Visibility, textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
-        azRailItem(id = "save", text = "Save", route = "save", content = Icons.Default.Save, textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
+        // No `content` icon on these items: AzNavRail renders a rail item as its icon
+        // when it has content, or as its text label when content is omitted (as the
+        // content-less Help item already does). Text labels are what we want here.
+        azRailItem(id = "load", text = "Load", route = "load", textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
+        azRailItem(id = "data", text = "Data", route = "data", textColor = Color.White, info = "Pick what the code carries — a link, a contact card, or social profiles — and fill in the details.")
+        azRailItem(id = "presets", text = "Presets", route = "presets", textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
+        azRailItem(id = "design", text = "Design", route = "design", textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
+        azRailItem(id = "preview", text = "Preview", route = "preview", textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
+        azRailItem(id = "save", text = "Save", route = "save", textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
         // Launches the standalone "pass a file on" flow (same-Wi-Fi hand-off).
         azRailItem(
             id = "send",
             text = "Send",
-            content = Icons.Default.Send,
-            color = Color.White,
             textColor = Color.White,
+            info = "Hand a file to a nearby phone on the same Wi-Fi; they scan the QR with their camera to download it.",
             onClick = { context.startActivity(Intent(context, SendFileActivity::class.java)) }
         )
         azHelpRailItem(id = "help", text = "Help", textColor = Color.White)


### PR DESCRIPTION
## Problem
On `main` the editor's AzNavRail still renders **icons** instead of text labels (see the running app: every item is an icon, only "Help" is text).

## Root cause
The icon-vs-text trigger is the item's **`content`** (icon), **not** `color`. AzNavRail draws a rail item as its icon when it has `content`, and as its **text label** when `content` is omitted — which is exactly why the content-less `azHelpRailItem` ("Help") was the only one showing as text. The earlier attempt to fix this by removing `color` had no effect.

## Fix
Remove `content` from every `azRailItem` (Load, Data, Presets, Design, Preview, Save, **and** the new Send item) so they all render as text labels, consistent with "Help". `textColor = Color.White` and the `info` help text are kept. Removed the now-unused icon imports.

## Notes
- Branched off current `main` (after #61 and #62 merged), so it applies cleanly.
- Couldn't compile here (the `foojay-resolver` Gradle plugin isn't cached and the network policy blocks resolving it) — a local build is worth it, but this is a small, contained change.

https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G)_

## Summary by Sourcery

Render AzNavRail rail items as text labels instead of icons for consistent navigation UI.

Bug Fixes:
- Ensure all AzNavRail items (including the new Send item) render as text labels by omitting icon content.

Enhancements:
- Remove unused Material icon imports related to the AzNavRail items.