### PR TITLE
Editor tweaks: rail color/shape, saved-code dates, file-send in Data screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,13 +46,6 @@
             android:theme="@style/Theme.QaRd" />
 
         <activity
-            android:name=".ui.SendFileActivity"
-            android:exported="false"
-            android:label="Send a file"
-            android:configChanges="orientation|screenSize|keyboardHidden"
-            android:theme="@style/Theme.QaRd" />
-
-        <activity
             android:name=".ui.WidgetMenuActivity"
             android:exported="false"
             android:excludeFromRecents="true"

--- a/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
+++ b/app/src/main/java/com/hereliesaz/qard/data/QrConfig.kt
@@ -114,6 +114,9 @@ data class QrConfig(
     val backgroundGradientColors: List<Int> = listOf(Color.White.toArgb(), Color.Black.toArgb()),
     val backgroundGradientAngle: Float = 0f,
     val backgroundAlpha: Float = 1f,
+    // Epoch millis when this config was first saved. 0 for legacy entries saved
+    // before timestamps existed (shown without a date on the Load screen).
+    val createdAt: Long = 0L,
 )
 
 @Serializable

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -120,6 +120,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import java.text.DateFormat
+import java.util.Date
 import kotlin.random.Random
 
 class ConfigActivity : ComponentActivity() {
@@ -307,8 +309,15 @@ fun ConfigScreen(
     // the Load screen and reloads later. Updates the tracked entry in place; in
     // widget mode it also writes through to the widget's own config.
     suspend fun persistCurrentConfig() {
-        val cfg = config ?: return
-        if (!cfg.hasContent()) return
+        val current = config ?: return
+        if (!current.hasContent()) return
+        // Stamp the creation time once, on the first save, and keep it in the editor
+        // state so later edits (which copy the config) carry it forward unchanged.
+        val cfg = if (current.createdAt == 0L) {
+            current.copy(createdAt = System.currentTimeMillis()).also { config = it }
+        } else {
+            current
+        }
         val saved = dataStore.getSavedConfigs().first().toMutableList()
         val previous = persistedSnapshot
         val idx = if (previous != null) saved.indexOf(previous) else -1
@@ -462,32 +471,22 @@ fun ConfigScreen(
     }
 
     AzHostActivityLayout(navController = navController) {
-        // Selected rail item highlight — logo pink so it stands out on the dark rail.
-        // Inactive rail items show their white text label; the active one is LogoPink.
-        // NOTE: giving a rail item a `color` makes AzNavRail render its icon in place
-        // of its text, so we set only `textColor` here to keep the labels as text.
-        azTheme(activeColor = LogoPink)
+        // Square rail buttons; the active item is recoloured to LogoPink so it stands
+        // out against the white inactive labels.
+        azTheme(activeColor = LogoPink, defaultShape = AzButtonShape.SQUARE)
         // Enable AzNavRail's help overlay: tapping the Help rail item draws info cards
         // linked to each rail item, sourced from the `info` text below.
         azAdvanced(helpEnabled = true)
         // No `content` icon on these items: AzNavRail renders a rail item as its icon
-        // when it has content, or as its text label when content is omitted (as the
-        // content-less Help item already does). Text labels are what we want here.
-        azRailItem(id = "load", text = "Load", route = "load", textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
-        azRailItem(id = "data", text = "Data", route = "data", textColor = Color.White, info = "Pick what the code carries — a link, a contact card, or social profiles — and fill in the details.")
-        // Launches the standalone "pass a file on" flow (same-Wi-Fi hand-off).
-        azRailItem(
-            id = "send",
-            text = "Send",
-            textColor = Color.White,
-            info = "Hand a file to a nearby phone on the same Wi-Fi; they scan the QR with their camera to download it.",
-            onClick = { context.startActivity(Intent(context, SendFileActivity::class.java)) }
-        )
-        azRailItem(id = "presets", text = "Presets", route = "presets", textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
-        azRailItem(id = "design", text = "Design", route = "design", textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
-        azRailItem(id = "preview", text = "Preview", route = "preview", textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
-        azRailItem(id = "save", text = "Save", route = "save", textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
-        azHelpRailItem(id = "help", text = "Help", textColor = Color.White)
+        // when it has content, or as its text label when content is omitted. We want text
+        // labels, coloured white (the active item is recoloured to LogoPink by azTheme).
+        azRailItem(id = "load", text = "Load", route = "load", color = Color.White, textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
+        azRailItem(id = "data", text = "Data", route = "data", color = Color.White, textColor = Color.White, info = "Pick what the code carries — a link, a contact card, social profiles, or a file to send — and fill it in.")
+        azRailItem(id = "presets", text = "Presets", route = "presets", color = Color.White, textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
+        azRailItem(id = "design", text = "Design", route = "design", color = Color.White, textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
+        azRailItem(id = "preview", text = "Preview", route = "preview", color = Color.White, textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
+        azRailItem(id = "save", text = "Save", route = "save", color = Color.White, textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
+        azHelpRailItem(id = "help", text = "Help", color = Color.White, textColor = Color.White)
 
 
         onscreen {
@@ -658,6 +657,9 @@ fun DataScreen(
                 updateConfig = updateConfig
             )
         }
+        // Sending a file is set up here too: it produces its own scannable QR rather
+        // than encoding into the card above.
+        FileSendSection()
     }
 }
 
@@ -904,7 +906,7 @@ fun PresetsScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             gridItems(presets) { preset ->
-                Card(onClick = { updateConfig(preset.copy(data = currentConfig.data)) }) {
+                Card(onClick = { updateConfig(preset.copy(data = currentConfig.data, createdAt = currentConfig.createdAt)) }) {
                     Column(
                         modifier = Modifier.padding(12.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -972,8 +974,30 @@ fun LoadScreen(
                                 onLongClick = { pendingDelete = savedConfig }
                             )
                     ) {
-                        Box(modifier = Modifier.padding(8.dp)) {
+                        // Same tile layout as the Presets grid so the previews match in
+                        // size; the created-date sits below like the preset's shape label.
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
                             QrCodePreview(config = savedConfig, title = null, imageSize = 96.dp)
+                            val created = remember(savedConfig.createdAt) {
+                                if (savedConfig.createdAt > 0L) {
+                                    DateFormat.getDateTimeInstance(
+                                        DateFormat.MEDIUM, DateFormat.SHORT
+                                    ).format(Date(savedConfig.createdAt))
+                                } else {
+                                    null
+                                }
+                            }
+                            if (created != null) {
+                                Text(
+                                    created,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    textAlign = TextAlign.Center
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/hereliesaz/qard/ui/FileSendSection.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/FileSendSection.kt
@@ -2,25 +2,24 @@ package com.hereliesaz.qard.ui
 
 import android.content.Context
 import android.net.Uri
-import android.os.Bundle
 import android.provider.OpenableColumns
 import android.text.format.Formatter
 import android.util.Log
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -38,24 +37,7 @@ import com.hereliesaz.qard.data.QrConfig
 import com.hereliesaz.qard.data.QrData
 import com.hereliesaz.qard.transfer.LocalFileServer
 import com.hereliesaz.qard.transfer.NetworkUtils
-import com.hereliesaz.qard.ui.theme.QaRdTheme
 import com.hereliesaz.qard.widget.QrGenerator
-
-/**
- * Sender-only "pass it on" screen for files. Phase 1: same-Wi-Fi hand-off — pick a file,
- * serve it from a local HTTP server, and show a QR of the URL. The receiver scans it with
- * their stock camera; no app, no scanner, no account needed on the other end.
- */
-class SendFileActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContent {
-            QaRdTheme {
-                SendFileScreen()
-            }
-        }
-    }
-}
 
 private sealed interface SendState {
     data object Idle : SendState
@@ -68,8 +50,14 @@ private sealed interface SendState {
     ) : SendState
 }
 
+/**
+ * A Data-screen section for the sender-only "pass a file on" flow. Pick a file, serve it
+ * from a local HTTP server, and show a QR of the URL. A receiver on the same Wi-Fi scans
+ * it with their stock camera and the file downloads in their browser — no app, scanner, or
+ * account on the other end. The server lives only while this section is on screen.
+ */
 @Composable
-fun SendFileScreen() {
+fun FileSendSection() {
     val context = LocalContext.current
     var state by remember { mutableStateOf<SendState>(SendState.Idle) }
     var server by remember { mutableStateOf<LocalFileServer?>(null) }
@@ -102,7 +90,7 @@ fun SendFileScreen() {
         try {
             srv.start(NanoHttpdTimeoutMs, false)
         } catch (e: Exception) {
-            Log.e("SendFileActivity", "Failed to start local server", e)
+            Log.e("FileSendSection", "Failed to start local server", e)
             state = SendState.Error("Couldn't start the local server. Try again.")
             return@rememberLauncherForActivityResult
         }
@@ -110,90 +98,87 @@ fun SendFileScreen() {
         state = SendState.Serving(srv.url(ip), meta.name, meta.size)
     }
 
-    // Tear the server down when the screen leaves composition.
+    // Tear the server down when the section leaves composition.
     DisposableEffect(Unit) {
         onDispose { stopServer() }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        when (val s = state) {
-            is SendState.Idle -> {
-                Text(
-                    "Send a file to a nearby phone on the same Wi-Fi. Pick a file and a QR " +
-                        "appears — the other person scans it with their normal camera and the " +
-                        "file downloads in their browser. No app needed on their end.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(imageVector = Icons.Default.Send, contentDescription = null)
+                Text("Send a file", style = MaterialTheme.typography.titleMedium)
             }
 
-            is SendState.NoNetwork -> {
-                Text(
-                    "You're not on a Wi-Fi network. Connect both phones to the same Wi-Fi, " +
-                        "then try again.",
+            when (val s = state) {
+                is SendState.Idle -> Text(
+                    "Pick a file and a QR appears. Someone on the same Wi-Fi scans it with their " +
+                        "normal camera and the file downloads in their browser — no app needed.",
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
                 )
-            }
 
-            is SendState.Error -> {
-                Text(
+                is SendState.NoNetwork -> Text(
+                    "You're not on a Wi-Fi network. Connect both phones to the same Wi-Fi, then " +
+                        "try again.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+
+                is SendState.Error -> Text(
                     s.message,
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
                 )
+
+                is SendState.Serving -> {
+                    val bitmap = remember(s.url) {
+                        QrGenerator.generate(
+                            QrConfig(data = listOf(QrData.Links(links = listOf(s.url))))
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (bitmap != null) {
+                            Image(
+                                bitmap = bitmap.asImageBitmap(),
+                                contentDescription = "QR code for the file download link",
+                                modifier = Modifier.size(220.dp),
+                            )
+                        }
+                        Text(
+                            s.fileName,
+                            style = MaterialTheme.typography.titleSmall,
+                            textAlign = TextAlign.Center,
+                        )
+                        if (s.fileSize >= 0) {
+                            Text(
+                                Formatter.formatFileSize(context, s.fileSize),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                        Text(
+                            "Have them scan this while you stay on this screen — the link stops " +
+                                "working when you leave.",
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
             }
 
-            is SendState.Serving -> {
-                val bitmap = remember(s.url) {
-                    QrGenerator.generate(
-                        QrConfig(data = listOf(QrData.Links(links = listOf(s.url))))
-                    )
-                }
-                if (bitmap != null) {
-                    Image(
-                        bitmap = bitmap.asImageBitmap(),
-                        contentDescription = "QR code for the file download link",
-                        modifier = Modifier.size(280.dp),
-                    )
-                }
-                Text(
-                    s.fileName,
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                )
-                if (s.fileSize >= 0) {
-                    Text(
-                        Formatter.formatFileSize(context, s.fileSize),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-                Text(
-                    "Have them scan this with their camera while you stay on this screen. " +
-                        "The link stops working when you leave.",
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    s.url,
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                )
+            OutlinedButton(
+                onClick = { picker.launch(arrayOf("*/*")) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (state is SendState.Serving) "Pick another file" else "Choose a file")
             }
-        }
-
-        Button(
-            onClick = { picker.launch(arrayOf("*/*")) },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(if (state is SendState.Serving) "Pick another file" else "Choose a file")
         }
     }
 }


### PR DESCRIPTION
Bundles five editor/UI fixes you asked for.

## Rail
- **White labels:** each rail item now sets `color = Color.White` so inactive labels render white (they were showing the theme's purple); the active item is recoloured to **LogoPink** by `azTheme(activeColor = ...)`.
- **Square buttons:** `azTheme(defaultShape = AzButtonShape.SQUARE)`.

## Load screen
- **Preview size now matches Presets:** the Load tiles use the same `Column(padding = 12.dp)` layout as the Presets grid (they previously used a tighter `Box(padding = 8.dp)`), so the QR previews render at the same size.
- **Created date/time:** saved codes now carry a `createdAt` timestamp (`QrConfig`), stamped on first save and preserved across edits and preset application. The Load screen shows the formatted date/time under each preview (legacy codes saved before this have no timestamp and simply show no date).

## Send → Data
- **Removed the standalone Send screen/activity** and folded the file-send setup into the **Data screen** as a `FileSendSection` card (pick a file → local HTTP server → URL QR for a same-Wi-Fi, stock-camera download). It now lives within the AzNavRail layout like every other section instead of a separate plain-Compose activity. Manifest activity entry removed; network permissions kept.

## Notes
- Branched off current `main`.
- Couldn't compile here (the `foojay-resolver` Gradle plugin isn't cached / network-blocked), so a local build is worth it. One thing to verify on device: `AzButtonShape.SQUARE` is the correct enum value for square rail buttons in AzNavRail 9.13 (used per the DSL signature).

https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G)_

## Summary by Sourcery

Integrate the file-send flow into the Data screen, align editor navigation styling, and add created timestamps to saved QR configs with corresponding UI updates.

New Features:
- Expose a file-send section directly within the Data screen to generate a QR download link for files shared over the local network.
- Track a created-at timestamp on saved QR configurations and display formatted creation dates in the Load screen tiles.

Enhancements:
- Style the navigation rail with white inactive labels, LogoPink active highlight, and square-shaped buttons.
- Align Load screen tile layout with the Presets grid so QR previews render at a consistent size across both screens.
- Ensure presets preserve the original configuration's creation timestamp when applied to keep save metadata consistent.

Chores:
- Remove the standalone SendFile activity and its manifest entry in favor of the embedded Data-screen section.