### PR TITLE
Rail active item renders pink (drop textColor override)

### DIFF
--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -477,16 +477,18 @@ fun ConfigScreen(
         // Enable AzNavRail's help overlay: tapping the Help rail item draws info cards
         // linked to each rail item, sourced from the `info` text below.
         azAdvanced(helpEnabled = true)
-        // No `content` icon on these items: AzNavRail renders a rail item as its icon
-        // when it has content, or as its text label when content is omitted. We want text
-        // labels, coloured white (the active item is recoloured to LogoPink by azTheme).
-        azRailItem(id = "load", text = "Load", route = "load", color = Color.White, textColor = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
-        azRailItem(id = "data", text = "Data", route = "data", color = Color.White, textColor = Color.White, info = "Pick what the code carries — a link, a contact card, social profiles, or a file to send — and fill it in.")
-        azRailItem(id = "presets", text = "Presets", route = "presets", color = Color.White, textColor = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
-        azRailItem(id = "design", text = "Design", route = "design", color = Color.White, textColor = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
-        azRailItem(id = "preview", text = "Preview", route = "preview", color = Color.White, textColor = Color.White, info = "See the finished QR code at full size before you save or share it.")
-        azRailItem(id = "save", text = "Save", route = "save", color = Color.White, textColor = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
-        azHelpRailItem(id = "help", text = "Help", color = Color.White, textColor = Color.White)
+        // No `content` icon: AzNavRail renders an item's text label when content is
+        // omitted. `color` is the button's base (border + text) colour, white here; the
+        // active item is recoloured to LogoPink via azTheme(activeColor). We deliberately
+        // do NOT set `textColor` — it overrides the active colour and would keep the
+        // selected item's text white instead of pink.
+        azRailItem(id = "load", text = "Load", route = "load", color = Color.White, info = "Browse and reload your saved QR codes. Tap one to edit it; long-press to delete.")
+        azRailItem(id = "data", text = "Data", route = "data", color = Color.White, info = "Pick what the code carries — a link, a contact card, social profiles, or a file to send — and fill it in.")
+        azRailItem(id = "presets", text = "Presets", route = "presets", color = Color.White, info = "Apply a ready-made colour-and-shape style to your data with a single tap.")
+        azRailItem(id = "design", text = "Design", route = "design", color = Color.White, info = "Customise the code's shape, foreground and background colours, gradients, and transparency.")
+        azRailItem(id = "preview", text = "Preview", route = "preview", color = Color.White, info = "See the finished QR code at full size before you save or share it.")
+        azRailItem(id = "save", text = "Save", route = "save", color = Color.White, info = "Save the code as an image or add it to your home screen as a widget. Edits auto-save as you go.")
+        azHelpRailItem(id = "help", text = "Help", color = Color.White)
 
 
         onscreen {


### PR DESCRIPTION
I read the AzNavRail 9.13 source directly (cloned the repo) instead of guessing. Findings:

- `AzButtonShape.SQUARE` **is** valid (`model/AzButtonShape.kt`: CIRCLE, SQUARE, RECTANGLE, NONE), so the square-shape change on `main` is correct.
- `azTheme(activeColor, defaultShape, …)` and the `color`/`textColor`/`info` params all match the real `AzNavRailScope` signatures.
- **The bug:** in `AzNavRailButton.kt`, the text colour is `finalTextColor = textColor ?: (if (isPressed || isSelected) activeColor else color)`. Setting `textColor = Color.White` on each item therefore **overrode the active colour**, keeping the selected item's text white instead of LogoPink. And without any `color`, items fall back to `MaterialTheme.colorScheme.primary` (the purple you saw).

## Fix
Keep **only `color = Color.White`** on each rail item (and the Help item); drop `textColor`. Result, per the source:
- Inactive: `finalColor = color` = white → white border + text.
- Active/selected: `finalColor = activeColor` = LogoPink → pink border + text.

That gives exactly "white labels, active one pink."

https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G)_

## Summary by Sourcery

Bug Fixes:
- Allow the active navigation rail item to render in the themed LogoPink color by removing the text color override from all rail items and the Help item.