### PR TITLE
Fix widget not resizable: restore maxResize bounds (Launcher3 needs them)

### DIFF
--- a/app/src/main/res/xml/qr_widget_info.xml
+++ b/app/src/main/res/xml/qr_widget_info.xml
@@ -8,6 +8,8 @@
     android:minResizeHeight="40dp"
     android:targetCellWidth="2"
     android:targetCellHeight="2"
+    android:maxResizeWidth="1200dp"
+    android:maxResizeHeight="1200dp"
     android:previewImage="@mipmap/ic_launcher"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="86400000"


### PR DESCRIPTION
## Problem
The widget shows **no resize handles** on the stock Pixel launcher.

## Root cause (regression in `602c2b2`)
That commit removed `maxResizeWidth`/`maxResizeHeight` to allow full-width resizing. But Launcher3 (Pixel/stock AOSP) derives a widget's **max resize span** from those attributes. With them absent, the max span collapses to the target span, so the launcher concludes the widget can't grow and **offers no resize handles** — even though `resizeMode="horizontal|vertical"` is set. (The earlier version with `maxResize=640dp` *was* resizable; removing it is what broke it.)

## Fix
Re-add `maxResizeWidth`/`maxResizeHeight` at a large **1200dp**. That gives Launcher3 the explicit upper bound it needs to show resize handles, while still allowing resize up to the full grid — the launcher clamps to the actual grid, so 1200dp isn't a practical cap (avoids the "capped at 4/5 width" issue the removal was trying to solve).

Net: `minResize 40dp` → `maxResize 1200dp`, `resizeMode horizontal|vertical`, Glance `SizeMode.Exact` — freely resizable again.

Note: if a stale widget instance was placed by a previous build, it may need to be removed and re-added once for the launcher to pick up the refreshed provider info.

https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDUnEvQjrF3JkzEuWpZ41G)_

## Summary by Sourcery

Bug Fixes:
- Reintroduce large maxResizeWidth/maxResizeHeight values for the QR widget so stock/Launcher3-based launchers show resize handles and allow resizing.