### PR TITLE
Modular Google Play delivery: signed AAB, monotonic versionCode, DFM scaffold (+ JitPack timeout fix)

### DIFF
--- a/.github/workflows/play-release.yml
+++ b/.github/workflows/play-release.yml
@@ -1,0 +1,132 @@
+name: Play Release (AAB)
+
+# Manually-triggered build + publish of a signed Android App Bundle to the Google
+# Play Console. Defaults are deliberately safe: internal track, draft status, and
+# publishing OFF (build + upload the .aab as a CI artifact only). Flip `publish` on
+# to actually push to Play.
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: "Play track to release to"
+        type: choice
+        default: internal
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      status:
+        description: "Release status on the chosen track"
+        type: choice
+        default: draft
+        options:
+          - draft
+          - completed
+      publish:
+        description: "Publish to Play (off = build + upload the .aab artifact only)"
+        type: boolean
+        default: false
+
+jobs:
+  bundle-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the monotonic versionCode (commit count) is correct.
+          fetch-depth: 0
+
+      - name: Generate Keystore from Secrets
+        env:
+          KEYSTORE_PRIVATE: ${{ secrets.KEYSTORE_PRIVATE }}
+          KEYSTORE_CHAIN: ${{ secrets.KEYSTORE_CHAIN }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          echo "Generating keystore from certificate chain and private key..."
+          echo "$KEYSTORE_PRIVATE" > private_key.pem
+          echo "$KEYSTORE_CHAIN" > certificate_chain.crt
+
+          openssl pkcs12 -export -in certificate_chain.crt -inkey private_key.pem \
+            -name "$KEY_ALIAS" -out keystore.p12 \
+            -password pass:"$KEYSTORE_PASSWORD"
+
+          keytool -importkeystore -srckeystore keystore.p12 -srcstoretype PKCS12 \
+            -destkeystore app/keystore.jks -deststoretype JKS \
+            -srcstorepass "$KEYSTORE_PASSWORD" \
+            -deststorepass "$KEYSTORE_PASSWORD" \
+            -alias "$KEY_ALIAS" -noprompt
+
+          echo "Keystore generated at app/keystore.jks"
+          rm private_key.pem certificate_chain.crt keystore.p12
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        with:
+          cache-read-only: false
+          dependency-graph: disabled
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Build the signed Play (AdMob) App Bundle. versionCode = commit count, which
+      # strictly increases on every commit so Play never rejects a duplicate/lower
+      # code. The Android App Bundle automatically produces per-device density, ABI,
+      # and language splits at install time — no separate artifacts to build.
+      - name: Build signed AAB
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          VERSION_CODE=$(git rev-list --count HEAD)
+          echo "Building bundlePlayRelease with versionCode=$VERSION_CODE"
+          ./gradlew bundlePlayRelease -PversionBuild=$VERSION_CODE --build-cache \
+            -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
+            -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+            -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+            -Pandroid.injected.signing.key.password=$KEY_PASSWORD
+
+      - name: Locate AAB
+        id: aab
+        run: |
+          AAB=$(find app/build/outputs/bundle/playRelease -name "*.aab" | head -n 1)
+          if [ -z "$AAB" ]; then
+            echo "No .aab produced!" >&2
+            exit 1
+          fi
+          echo "path=$AAB" >> "$GITHUB_OUTPUT"
+          echo "Found AAB: $AAB"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qard-play-release-aab
+          path: ${{ steps.aab.outputs.path }}
+          if-no-files-found: error
+
+      # applicationId is com.hereliesaz.qard for both flavors (no suffix), so the
+      # Play packageName is fixed; r0adkll has no "read from build" hook, hence the
+      # explicit value here. Keep it in sync with app/build.gradle.kts applicationId.
+      - name: Publish to Google Play
+        if: ${{ inputs.publish }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.hereliesaz.qard
+          releaseFiles: ${{ steps.aab.outputs.path }}
+          track: ${{ inputs.track }}
+          status: ${{ inputs.status }}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ Share your contact info, files, or social media with a QR code widget. A simple 
 3.  Customize the QaRd design.
 4. Huzzah. Your home screen now displays your QaRd. Resize for the perfect fit—it stays crisp!
 
+## Building & Releasing
+
+The ad-free **foss** build ships as a signed APK to GitHub Releases (see
+`.github/workflows/build.yml`). The Play Store build is the **play** flavor, packaged as a
+signed **Android App Bundle** with automatic per-device splits and a dynamic feature module
+scaffold for on-demand delivery.
+
+```bash
+# Signed Play App Bundle (reads signing creds from local.properties):
+./gradlew bundlePlayRelease -PversionBuild=$(git rev-list --count HEAD)
+```
+
+Publishing to Play is a manual `workflow_dispatch` run of **Play Release (AAB)**
+(`.github/workflows/play-release.yml`) — defaults to the *internal* track, *draft* status,
+and publishing **off** (build + upload the `.aab` artifact only). Full details, required
+secrets, the one-time Play service-account setup, and the dynamic-feature delivery model
+are in [`docs/play-delivery.md`](docs/play-delivery.md).
+
 ## Lock Screen Availability
 
 **Important Note on Lock Screen Availability:**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
 // lower versionCode. When no override is supplied we keep the original local
 // behaviour: auto-increment on release/bundle builds and persist it to
 // version.properties.
-val versionBuildOverride = (project.findProperty("versionBuild") as String?)?.trim()?.toIntOrNull()
+val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.trim()?.toIntOrNull()
 val isReleaseBuild = gradle.startParameter.taskNames.any {
     it.contains("Release", ignoreCase = true) || it.contains("bundle", ignoreCase = true)
 }
@@ -178,10 +178,12 @@ dependencies {
     // Menu
     implementation(libs.aznavrail)
 
-    // Play Feature Delivery — SplitInstallManager for installing/loading on-demand
-    // dynamic feature modules at runtime. Pulled into both flavors because it governs
-    // app-bundle module delivery, not ads.
-    implementation(libs.play.feature.delivery)
+    // Play Feature Delivery — SplitInstallManager / SplitCompat for installing and
+    // loading on-demand dynamic feature modules at runtime. Proprietary Google Play
+    // Core code, so it's confined to the `play` flavor to keep the FOSS build (and
+    // F-Droid distribution) free of non-free dependencies. Flavor-specific
+    // SplitCompatUtils (src/{foss,play}) wraps it so shared code never references it.
+    "playImplementation"(libs.play.feature.delivery)
 
     // Local HTTP server for same-Wi-Fi file hand-off (sender side).
     implementation(libs.nanohttpd)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,11 +25,18 @@ val localProperties = Properties().apply {
 
 var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
 
-// Automatically increment versionCode for release builds.
+// An explicit override always wins, e.g. CI passes a strictly-increasing value via
+// `-PversionBuild=$(git rev-list --count HEAD)` so Play never sees a duplicate or
+// lower versionCode. When no override is supplied we keep the original local
+// behaviour: auto-increment on release/bundle builds and persist it to
+// version.properties.
+val versionBuildOverride = (project.findProperty("versionBuild") as String?)?.trim()?.toIntOrNull()
 val isReleaseBuild = gradle.startParameter.taskNames.any {
     it.contains("Release", ignoreCase = true) || it.contains("bundle", ignoreCase = true)
 }
-if (isReleaseBuild) {
+if (versionBuildOverride != null) {
+    currentVersionCode = versionBuildOverride
+} else if (isReleaseBuild) {
     currentVersionCode++
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
     versionPropsFile.outputStream().use {
@@ -45,6 +52,12 @@ val currentVersionName = "$verMajor.$verMinor.$verPatch"
 android {
     namespace = "com.hereliesaz.qard"
     compileSdk = 37 // SDK 37 is not yet stable/standard; changing to 35 for better compatibility
+
+    // Dynamic feature modules. These ship inside the Android App Bundle and are
+    // delivered by Google Play (install-time / on-demand per each module's
+    // <dist:module> manifest), keeping the base install lean. They are NOT part
+    // of the standalone foss APK published to GitHub Releases.
+    dynamicFeatures += ":feature_transfer"
 
     defaultConfig {
         applicationId = "com.hereliesaz.qard"
@@ -164,6 +177,11 @@ dependencies {
 
     // Menu
     implementation(libs.aznavrail)
+
+    // Play Feature Delivery — SplitInstallManager for installing/loading on-demand
+    // dynamic feature modules at runtime. Pulled into both flavors because it governs
+    // app-bundle module delivery, not ads.
+    implementation(libs.play.feature.delivery)
 
     // Local HTTP server for same-Wi-Fi file hand-off (sender side).
     implementation(libs.nanohttpd)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,30 @@
+# Add project specific ProGuard rules here.
+# Minification (isMinifyEnabled) is currently OFF for the release build — see
+# app/build.gradle.kts and docs/play-delivery.md. These rules are kept ready so R8
+# can be enabled safely later without breaking reflection/serialization.
+
+# --- kotlinx.serialization -------------------------------------------------
+# The plugin generates a synthetic Companion + .Companion.serializer(); keep
+# generated serializers and the @Serializable types they belong to. (The library
+# also ships consumer rules, but we keep these explicit for our own models.)
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class com.hereliesaz.qard.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.hereliesaz.qard.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.hereliesaz.qard.**$$serializer { *; }
+
+# --- NanoHTTPD -------------------------------------------------------------
+# Reflectively-touched HTTP server used by the file-transfer feature.
+-keep class org.nanohttpd.** { *; }
+-dontwarn org.nanohttpd.**
+
+# --- Play Feature Delivery / SplitCompat -----------------------------------
+-keep class com.google.android.play.core.** { *; }
+-dontwarn com.google.android.play.core.**
+
+# Dynamic feature entry points are loaded by class name after install; keep them.
+-keep class com.hereliesaz.qard.feature.** { *; }

--- a/app/src/foss/java/com/hereliesaz/qard/splitcompat/SplitCompatUtils.kt
+++ b/app/src/foss/java/com/hereliesaz/qard/splitcompat/SplitCompatUtils.kt
@@ -1,0 +1,20 @@
+package com.hereliesaz.qard.splitcompat
+
+import android.app.Activity
+import android.content.Context
+
+/**
+ * FOSS (ad-free) implementation. The FOSS build ships as a single APK distributed
+ * outside Google Play, so there are no on-demand splits to attach and no proprietary
+ * Play Core dependency — every call is a no-op. The matching `play` flavor (src/play)
+ * provides the real SplitCompat-backed implementation.
+ */
+object SplitCompatUtils {
+    fun install(context: Context) {
+        // No dynamic feature splits in the FOSS build.
+    }
+
+    fun installActivity(activity: Activity) {
+        // No dynamic feature splits in the FOSS build.
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
+++ b/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
@@ -1,6 +1,8 @@
 package com.hereliesaz.qard
 
 import android.app.Application
+import android.content.Context
+import com.google.android.play.core.splitcompat.SplitCompat
 import com.hereliesaz.qard.ads.initAds
 
 /**
@@ -8,6 +10,13 @@ import com.hereliesaz.qard.ads.initAds
  * SDK in the `play` build and is a no-op in the ad-free `foss` build.
  */
 class QaRdApp : Application() {
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        // Make on-demand dynamic feature module code/resources available to the
+        // whole process after Play installs a split at runtime.
+        SplitCompat.install(this)
+    }
+
     override fun onCreate() {
         super.onCreate()
         initAds(this)

--- a/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
+++ b/app/src/main/java/com/hereliesaz/qard/QaRdApp.kt
@@ -2,8 +2,8 @@ package com.hereliesaz.qard
 
 import android.app.Application
 import android.content.Context
-import com.google.android.play.core.splitcompat.SplitCompat
 import com.hereliesaz.qard.ads.initAds
+import com.hereliesaz.qard.splitcompat.SplitCompatUtils
 
 /**
  * Application entry point. [initAds] is flavor-specific: it initializes the AdMob
@@ -13,8 +13,9 @@ class QaRdApp : Application() {
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
         // Make on-demand dynamic feature module code/resources available to the
-        // whole process after Play installs a split at runtime.
-        SplitCompat.install(this)
+        // whole process after Play installs a split at runtime. Flavor-specific:
+        // real on `play`, a no-op on the FOSS build (no proprietary Play Core).
+        SplitCompatUtils.install(this)
     }
 
     override fun onCreate() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="tap_to_unlock">Tap to unlock</string>
     <string name="qr_code_image_description">QR Code</string>
     <string name="widget_placeholder_text">Configure to show QR code</string>
+    <!-- Title for the on-demand :feature_transfer dynamic feature module. Must live in
+         the base module so Play can show it during install. -->
+    <string name="feature_transfer_title">File transfer</string>
 </resources>

--- a/app/src/play/java/com/hereliesaz/qard/splitcompat/SplitCompatUtils.kt
+++ b/app/src/play/java/com/hereliesaz/qard/splitcompat/SplitCompatUtils.kt
@@ -1,0 +1,21 @@
+package com.hereliesaz.qard.splitcompat
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.play.core.splitcompat.SplitCompat
+
+/**
+ * Play implementation. Installs SplitCompat so on-demand dynamic feature modules that
+ * Google Play delivers at runtime are visible to the running process / Activity. The
+ * proprietary Play Core dependency lives only in this flavor (see `playImplementation`
+ * in build.gradle.kts); the FOSS flavor (src/foss) provides no-op equivalents.
+ */
+object SplitCompatUtils {
+    fun install(context: Context) {
+        SplitCompat.install(context)
+    }
+
+    fun installActivity(activity: Activity) {
+        SplitCompat.installActivity(activity)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.dynamic.feature) apply false
     alias(libs.plugins.kotlin.android) apply false
     id("com.google.protobuf") version "0.9.5" apply false
     alias(libs.plugins.kotlinx.serialization) apply false

--- a/docs/play-delivery.md
+++ b/docs/play-delivery.md
@@ -1,0 +1,169 @@
+# Google Play delivery — App Bundle, signing & modular delivery
+
+How QaRd is packaged and shipped to Google Play: a **signed Android App Bundle (AAB)**
+with a **monotonic versionCode**, automatic device splits, and a dynamic feature module
+scaffold for on-demand delivery.
+
+> The ad-free **foss** flavor still ships as a single signed **APK** to GitHub Releases
+> via `.github/workflows/build.yml`. The Play path described here builds the **play**
+> flavor (with the AdMob SDK) as an **AAB**.
+
+---
+
+## 1. Build a signed AAB locally
+
+The release `signingConfig` reads a git-ignored `local.properties`:
+
+```properties
+# local.properties (never commit this)
+KEYSTORE=/absolute/path/to/upload-keystore.jks
+KEYSTORE_SECRET=<keystore password>
+KEY_ALIAS=<key alias>
+KEY_SECRET=<key password>
+```
+
+Then:
+
+```bash
+# Play flavor, signed, AAB:
+./gradlew bundlePlayRelease
+
+# Output:
+app/build/outputs/bundle/playRelease/app-play-release.aab
+```
+
+If no keystore is configured the build falls back to the debug key (so contributors can
+still build), which Play will reject — configure the keystore above for real uploads.
+
+### versionCode override
+
+`versionName` comes from `version.properties` (`major.minor.patch`). `versionCode` is:
+
+- **`-PversionBuild=<n>` when passed** — wins over everything. CI passes
+  `git rev-list --count HEAD`, which strictly increases on every commit, so Play never
+  sees a duplicate or lower code.
+- **auto-increment otherwise** — local release/bundle builds bump `versionBuild` in
+  `version.properties` and write it back (original behaviour, unchanged).
+
+```bash
+./gradlew bundlePlayRelease -PversionBuild=$(git rev-list --count HEAD)
+```
+
+---
+
+## 2. Publish via CI
+
+`.github/workflows/play-release.yml` is `workflow_dispatch`-triggered with inputs:
+
+| Input | Default | Meaning |
+| --- | --- | --- |
+| `track` | `internal` | `internal` / `alpha` / `beta` / `production` |
+| `status` | `draft` | `draft` (staged in console) or `completed` (rolled out) |
+| `publish` | `false` | **off** = build + upload the `.aab` as a CI artifact only; **on** = also push to Play |
+
+The job: checkout (full history) → materialize the upload keystore from secrets → JDK 17
++ Gradle → `bundlePlayRelease` with the commit-count versionCode and injected signing →
+upload the `.aab` artifact → (if `publish`) `r0adkll/upload-google-play@v1`.
+
+Defaults are safe: with `publish=false` nothing reaches Play — you just get the signed
+bundle as a downloadable artifact to sanity-check.
+
+---
+
+## 3. Modular delivery & size
+
+### Automatic splits (free)
+
+An AAB is **not** a single APK. Google Play generates and serves per-device **density**,
+**ABI**, and **language** split APKs from it automatically — each user downloads only what
+their device needs. No extra artifacts to build or configure; this is on the moment you
+ship an AAB instead of an APK.
+
+### Dynamic feature module: `:feature_transfer`
+
+`:feature_transfer` is a `com.android.dynamic-feature` module wired into `settings.gradle`
+and the base module's `android.dynamicFeatures`. Its manifest declares **on-demand**
+delivery (`<dist:delivery><dist:on-demand/>`), so its code/resources are **not** in the
+base install — Play delivers them at runtime on request.
+
+Today it ships a small placeholder (`TransferFeatureActivity`) so the bundle/Play Feature
+Delivery wiring is real and CI-verifiable. The file-transfer feature itself
+(`LocalFileServer` / `NetworkUtils` / `FileSendSection`) still lives in `:app` because it
+is compile-time-coupled to `ConfigActivity`; migrating it on-demand is a follow-up that
+needs the runtime-load indirection below plus a device test.
+
+**Loading an on-demand module at runtime** (from the base app):
+
+```kotlin
+val manager = SplitInstallManagerFactory.create(context)
+val request = SplitInstallRequest.newBuilder()
+    .addModule("feature_transfer")
+    .build()
+manager.startInstall(request)
+    .addOnSuccessListener { /* module installed; launch its Activity by class name */ }
+    .addOnFailureListener { /* surface error / retry */ }
+```
+
+Both the base `Application` (`QaRdApp.attachBaseContext`) and the module's Activity install
+`SplitCompat` so freshly-downloaded splits are visible to the running process. The base
+module stays installable on its own; on-demand modules only resolve when the app is
+installed **from Play** (a sideloaded/foss APK has no SplitInstall backend).
+
+### R8 / minification
+
+`isMinifyEnabled = false` for `release` today. Enabling R8 + resource shrinking would
+shrink the bundle further, but the app uses `kotlinx.serialization` (`@Serializable`
+models), reflective NanoHTTPD, Glance, and on-demand class loading — all of which need
+correct keep rules. `app/proguard-rules.pro` already contains those rules, but **enabling
+R8 must be validated on a device build first** (serialization round-trips, the widget, and
+file transfer), so it is left off until then.
+
+### Play in-app updates (optional follow-up)
+
+For nudging users onto newer versions, consider the Play in-app updates API
+(`com.google.android.play:app-update-ktx`) — flexible or immediate flows. Not wired up
+here; noted as a follow-up.
+
+---
+
+## 4. Required repo secrets
+
+| Secret | Used for |
+| --- | --- |
+| `KEYSTORE_PRIVATE` | Upload key private key (PEM) — assembled into the JKS in CI |
+| `KEYSTORE_CHAIN` | Upload key certificate chain (PEM) |
+| `KEYSTORE_PASSWORD` | Keystore + store password |
+| `KEY_ALIAS` | Key alias |
+| `KEY_PASSWORD` | Key password |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Google Cloud service-account JSON with Play publishing access |
+
+The signing secrets match the names already used by `build.yml`; only
+`PLAY_SERVICE_ACCOUNT_JSON` is new.
+
+### One-time Play setup (maintainer)
+
+1. In **Google Cloud Console**, create a service account; create a JSON key for it and
+   store the JSON as the `PLAY_SERVICE_ACCOUNT_JSON` repo secret.
+2. In the **Play Console** → *Users & permissions*, invite that service account and grant
+   it release permissions (at least the target track).
+3. **The first release of a brand-new app must be uploaded manually** in the Play Console
+   before the API can publish subsequent builds. Until that first manual upload exists,
+   `r0adkll/upload-google-play` will fail.
+4. Recommended: keep **Play App Signing** enabled — the keystore above is then your
+   *upload* key, and Play re-signs with the app signing key it holds.
+
+---
+
+## 5. Privacy / Data safety
+
+The **play** flavor bundles the **AdMob** SDK, which collects the advertising ID and
+device/usage signals and sends them to Google for ads. This has Play **Data safety**
+implications:
+
+- Declare data collection/sharing for advertising in the Play Console Data safety form.
+- The merged `play` manifest includes the `com.google.android.gms.permission.AD_ID`
+  permission (added by `play-services-ads`); declare advertising-ID usage accordingly.
+- Provide a privacy policy URL covering ads/third-party data.
+
+The **foss** flavor contains **no** ad SDK and makes no third-party network calls beyond
+the user-initiated same-Wi-Fi file hand-off, so its data-safety surface is minimal.

--- a/docs/play-delivery.md
+++ b/docs/play-delivery.md
@@ -109,6 +109,13 @@ Both the base `Application` (`QaRdApp.attachBaseContext`) and the module's Activ
 module stays installable on its own; on-demand modules only resolve when the app is
 installed **from Play** (a sideloaded/foss APK has no SplitInstall backend).
 
+**FOSS compliance.** The proprietary Play Core library (`feature-delivery`) is pulled in
+via `playImplementation` only, so the **foss** flavor (and any F-Droid build) stays free of
+non-free dependencies. Shared code never touches `SplitCompat` directly — it goes through
+`SplitCompatUtils` (`com.hereliesaz.qard.splitcompat`), which has a real Play
+implementation in `src/play` and a no-op in `src/foss`, mirroring the existing flavor-split
+`initAds` pattern. The foss build needs no splits anyway (single APK, no Play backend).
+
 ### R8 / minification
 
 `isMinifyEnabled = false` for `release` today. Enabling R8 + resource shrinking would

--- a/feature_transfer/build.gradle.kts
+++ b/feature_transfer/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    alias(libs.plugins.android.dynamic.feature)
+    alias(libs.plugins.kotlin.android)
+}
+
+// On-demand dynamic feature module scaffold. Today it ships a tiny placeholder
+// entry point so the app-bundle / Play Feature Delivery wiring is real and
+// CI-verifiable; the compile-time-coupled file-transfer feature still lives in
+// :app. See docs/play-delivery.md for how to migrate a feature into this module
+// and load it at runtime with SplitInstallManager.
+android {
+    namespace = "com.hereliesaz.qard.feature.transfer"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    // A dynamic feature depends on the base app module; flavors (foss/play),
+    // signing, and shared deps are all inherited from :app.
+    implementation(project(":app"))
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+}

--- a/feature_transfer/build.gradle.kts
+++ b/feature_transfer/build.gradle.kts
@@ -18,6 +18,16 @@ android {
         minSdk = 26
     }
 
+    // Mirror the base module's flavor dimension so this module's variants
+    // (fossDebug/playDebug/…) match :app's exactly. Without it, the
+    // implementation(project(":app")) dependency below is ambiguous — Gradle
+    // can't choose between :app's foss and play runtime variants.
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("foss") { dimension = "distribution" }
+        create("play") { dimension = "distribution" }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21

--- a/feature_transfer/build.gradle.kts
+++ b/feature_transfer/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
+    // AGP provides built-in Kotlin support (the base :app module likewise applies no
+    // separate kotlin.android plugin), so applying org.jetbrains.kotlin.android here
+    // would double-register the `kotlin` extension and fail.
     alias(libs.plugins.android.dynamic.feature)
-    alias(libs.plugins.kotlin.android)
 }
 
 // On-demand dynamic feature module scaffold. Today it ships a tiny placeholder

--- a/feature_transfer/src/main/AndroidManifest.xml
+++ b/feature_transfer/src/main/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution">
+
+    <!--
+      On-demand delivery: this module is NOT installed with the base app. It is
+      fetched at runtime via SplitInstallManager (see docs/play-delivery.md) and
+      only when delivered by Google Play. `instant="false"` keeps it out of
+      Google Play Instant. Switch `dist:onDemand` to an <dist:install-time>
+      element to have Play install it alongside the base instead.
+    -->
+    <dist:module
+        dist:instant="false"
+        dist:title="@string/feature_transfer_title">
+        <dist:delivery>
+            <dist:on-demand />
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:module>
+
+    <application>
+        <activity
+            android:name=".TransferFeatureActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/feature_transfer/src/main/java/com/hereliesaz/qard/feature/transfer/TransferFeatureActivity.kt
+++ b/feature_transfer/src/main/java/com/hereliesaz/qard/feature/transfer/TransferFeatureActivity.kt
@@ -1,0 +1,36 @@
+package com.hereliesaz.qard.feature.transfer
+
+import android.content.Context
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.play.core.splitcompat.SplitCompat
+
+/**
+ * Placeholder entry point for the on-demand `:feature_transfer` dynamic feature module.
+ *
+ * The base app launches this by class name only after the module has been installed
+ * with `SplitInstallManager` (see docs/play-delivery.md). Because the module's code and
+ * resources are delivered on-demand, every component in it must install [SplitCompat] in
+ * `attachBaseContext` so the freshly-downloaded split is visible to this process.
+ *
+ * Replace this with the real UI when the file-transfer feature is migrated here.
+ */
+class TransferFeatureActivity : AppCompatActivity() {
+
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        // Make the on-demand module's resources/code available to this component.
+        SplitCompat.installActivity(this)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val view = TextView(this).apply {
+            text = getString(com.hereliesaz.qard.R.string.feature_transfer_title)
+            gravity = Gravity.CENTER
+        }
+        setContentView(view)
+    }
+}

--- a/feature_transfer/src/main/java/com/hereliesaz/qard/feature/transfer/TransferFeatureActivity.kt
+++ b/feature_transfer/src/main/java/com/hereliesaz/qard/feature/transfer/TransferFeatureActivity.kt
@@ -5,15 +5,17 @@ import android.os.Bundle
 import android.view.Gravity
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.play.core.splitcompat.SplitCompat
+import com.hereliesaz.qard.splitcompat.SplitCompatUtils
 
 /**
  * Placeholder entry point for the on-demand `:feature_transfer` dynamic feature module.
  *
  * The base app launches this by class name only after the module has been installed
  * with `SplitInstallManager` (see docs/play-delivery.md). Because the module's code and
- * resources are delivered on-demand, every component in it must install [SplitCompat] in
- * `attachBaseContext` so the freshly-downloaded split is visible to this process.
+ * resources are delivered on-demand, every component in it must install SplitCompat in
+ * `attachBaseContext` so the freshly-downloaded split is visible to this process. That
+ * goes through [SplitCompatUtils] (flavor-specific: real on `play`, a no-op on FOSS) so
+ * this module pulls in no proprietary Play Core code in the FOSS build.
  *
  * Replace this with the real UI when the file-transfer feature is migrated here.
  */
@@ -22,7 +24,7 @@ class TransferFeatureActivity : AppCompatActivity() {
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
         // Make the on-demand module's resources/code available to this component.
-        SplitCompat.installActivity(this)
+        SplitCompatUtils.installActivity(this)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,12 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
+
+# Network timeouts for dependency resolution.
+# JitPack (used for com.github.hereliesaz:AzNavRail) builds artifacts on-demand
+# the first time a version is requested, which can take much longer than
+# Gradle's default 30s socket timeout and cause "Read timed out" failures in CI.
+# Raise the connection/socket timeouts to give slow remote repositories time to
+# respond. Values are in milliseconds.
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ appcompat = "1.7.0"
 constraintlayout = "2.2.0"
 navigationCompose = "2.8.4"
 playServicesAds = "23.6.0"
+playFeatureDelivery = "2.1.0"
 nanohttpd = "2.3.1"
 
 [libraries]
@@ -37,6 +38,9 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 
 # Google AdMob
 play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }
+
+# Play Feature Delivery (SplitInstall) for dynamic feature modules
+play-feature-delivery = { group = "com.google.android.play", name = "feature-delivery-ktx", version.ref = "playFeatureDelivery" }
 
 # Glance
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
@@ -63,6 +67,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidApplication" }
+android-dynamic-feature = { id = "com.android.dynamic-feature", version.ref = "androidApplication" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,3 +19,4 @@ dependencyResolutionManagement {
 }
 rootProject.name = "qard"
 include ':app'
+include ':feature_transfer'


### PR DESCRIPTION
## Summary

Two things, on one branch:

1. **JitPack timeout fix** — the failing CI build (`Read timed out` resolving `com.github.hereliesaz:AzNavRail:10.1`).
2. **Modular Google Play delivery** — signed App Bundle, monotonic versionCode, a publish workflow, and a dynamic-feature-module scaffold.

> ⚠️ **Not built/verified here** — this environment can't run a full Android build. Everything below is reasoned from the source and standard AGP/Play behavior; it needs a CI run (and a device for the on-demand split) to be confirmed. Draft until then.

---

### 1. JitPack read-timeout fix
JitPack builds artifacts on-demand the first time a version is requested, often longer than Gradle's default 30s socket timeout. Raised `connectionTimeout`/`socketTimeout` to 120s in `gradle.properties`.

### 2. Signed AAB + monotonic versionCode
- `versionCode` now honors **`-PversionBuild=<n>`** (CI passes `git rev-list --count HEAD`, strictly increasing so Play never rejects a duplicate/lower code). No override → existing local auto-increment behavior is unchanged.
- Reuses the repo's existing signing approach (in-file `signingConfigs.release` from `local.properties` locally; `-Pandroid.injected.signing.*` in CI).
- *Note:* the existing `build.yml` already passed `-PversionBuild` but the build never read it — this PR makes that flag actually take effect.

### 3. Play publish workflow
`.github/workflows/play-release.yml` — `workflow_dispatch` with inputs `track` (default `internal`), `status` (default `draft`), `publish` (default **false** = build + upload `.aab` artifact only). Builds signed `bundlePlayRelease`, uploads the artifact, then `r0adkll/upload-google-play@v1` only when `publish=true`. Matches `build.yml`'s JDK 17 / `setup-gradle@v4` / keystore-from-PEM-secrets conventions.

### 4. Modular delivery (safe scaffold)
- **Automatic splits** confirmed/documented — an AAB gives per-device density/ABI/language splits for free.
- **`:feature_transfer`** dynamic feature module (on-demand `<dist:delivery>`) wired into `settings.gradle` + base `dynamicFeatures`; `SplitCompat` enabled in `QaRdApp` and the module Activity. Ships a placeholder entry point so the bundle/Play Feature Delivery wiring is real and CI-verifiable. The file-transfer feature itself is compile-time-coupled to `ConfigActivity`, so it stays in `:app` — migrating it on-demand is a documented follow-up (per maintainer's "safe scaffold" choice).
- **R8/minify** left **off**: the app uses `kotlinx.serialization`, reflective NanoHTTPD, Glance, and on-demand class loading. Added the previously-missing `app/proguard-rules.pro` with the needed keep rules so R8 can be turned on once validated on a device.

### 5. Docs
`docs/play-delivery.md` (local AAB build, versionCode override, DFM delivery model + runtime SplitInstall snippet, secrets, one-time Play setup, Data safety) + a Building & Releasing section in the README.

---

## 🔧 Manual setup still required by the maintainer
- **New secret `PLAY_SERVICE_ACCOUNT_JSON`** — Google Cloud service-account JSON with Play publishing rights. (Signing secrets `KEYSTORE_PRIVATE` / `KEYSTORE_CHAIN` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD` are reused from `build.yml`.)
- In the **Play Console**, grant that service account release access on the target track.
- **First release of a brand-new app must be uploaded manually** in the console before the API can publish subsequent builds.
- **Data safety:** the `play` flavor bundles AdMob (collects advertising ID; adds the `AD_ID` permission) — declare ads data collection + a privacy policy in the console.

## Needs verification
- [ ] Full build green in CI (`./gradlew build`, `bundlePlayRelease`).
- [ ] On-demand `:feature_transfer` install/launch on a real device (Play track).
- [ ] `feature-delivery-ktx:2.1.0` / `SplitCompat` import resolve as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qDQ19HsDi3yuqqUHWcVPY)_