### PR TITLE
enforce version.properties as the sole version source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,10 +102,9 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           set +e
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
+
           # Build the ad-free FOSS APK (the artifact published to GitHub Releases).
-          ./gradlew assembleFossDebug -PversionBuild=$BUILD_NUMBER --build-cache \
+          ./gradlew assembleFossDebug --build-cache \
             -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
             -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
             -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
@@ -158,21 +157,11 @@ jobs:
         if: success() && github.event_name == 'push'
         id: release_vars
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
-          # Extract version info from properties file
-  
+          # All version components come from version.properties — the single source of truth.
           MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
           MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-
-          # Calculate Patch version programmatically based on commits since Minor update
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-    
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          fi
+          PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          BUILD_NUMBER=$(grep 'versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
 
           VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
           

--- a/.github/workflows/play-release.yml
+++ b/.github/workflows/play-release.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Full history so the monotonic versionCode (commit count) is correct.
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Generate Keystore from Secrets
         env:
@@ -82,17 +81,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # Build the signed Play (AdMob) App Bundle. versionCode = commit count, which
-      # strictly increases on every commit so Play never rejects a duplicate/lower
-      # code. The Android App Bundle automatically produces per-device density, ABI,
-      # and language splits at install time — no separate artifacts to build.
+      # Build the signed Play (AdMob) App Bundle. versionCode is read from
+      # version.properties (versionBuild). The Android App Bundle automatically
+      # produces per-device density, ABI, and language splits at install time.
       - name: Build signed AAB
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          VERSION_CODE=$(git rev-list --count HEAD)
+          VERSION_CODE=$(grep 'versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
           echo "Building bundlePlayRelease with versionCode=$VERSION_CODE"
           ./gradlew bundlePlayRelease -PversionBuild=$VERSION_CODE --build-cache \
             -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,11 +25,10 @@ val localProperties = Properties().apply {
 
 var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
 
-// An explicit override always wins, e.g. CI passes a strictly-increasing value via
-// `-PversionBuild=$(git rev-list --count HEAD)` so Play never sees a duplicate or
-// lower versionCode. When no override is supplied we keep the original local
-// behaviour: auto-increment on release/bundle builds and persist it to
-// version.properties.
+// An explicit override wins when provided (e.g. CI pins the exact versionBuild read
+// from version.properties via `-PversionBuild=<value>`). When no override is
+// supplied, release/bundle builds auto-increment versionBuild and persist it back
+// to version.properties so it remains the single source of truth.
 val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.trim()?.toIntOrNull()
 val isReleaseBuild = gradle.startParameter.taskNames.any {
     it.contains("Release", ignoreCase = true) || it.contains("bundle", ignoreCase = true)


### PR DESCRIPTION
## Summary

- **`build.yml`**: Removed `git rev-list --count HEAD` override for the debug build's versionCode. Replaced dynamic PATCH computation (via `git blame`) and git-count BUILD_NUMBER in "Prepare Release Variables" with direct reads of all four fields (`versionMajor`, `versionMinor`, `versionPatch`, `versionBuild`) from `version.properties`.
- **`play-release.yml`**: `VERSION_CODE` now reads `versionBuild` from `version.properties` instead of `git rev-list --count HEAD`. `fetch-depth` reduced to 1 since full history is no longer needed.
- **`app/build.gradle.kts`**: Updated comment to accurately reflect that CI pins the value read from `version.properties` (not a git-derived count).

## Test plan

- [ ] Trigger a debug build on a branch push; confirm the APK filename contains the version from `version.properties` (e.g. `2.4.5.25`)
- [ ] Trigger `play-release.yml` manually; confirm the logged `versionCode` matches `versionBuild` in `version.properties`
- [ ] Bump `versionPatch` in `version.properties`, push, and verify the new value propagates to the APK filename without any git-derived computation

---
_Generated by [Claude Code](https://claude.ai/code/session_014r8x1jfoHzGqgBsTzYAAQi)_