### PR TITLE
Add QR Code widget (1×1) alongside generic QaRd widget (2×2)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,5 +72,16 @@
                 android:resource="@xml/qr_widget_info" />
         </receiver>
 
+        <receiver
+            android:name=".widget.QrCodeWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/qr_code_widget_info" />
+        </receiver>
+
     </application>
 </manifest>

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -411,13 +411,9 @@ fun ConfigScreen(
         scope.launch {
             persistCurrentConfig()
             dataStore.savePendingPinConfig(cfg)
-            if (useQrCodeWidget) {
-                val provider = ComponentName(context, QrCodeWidgetReceiver::class.java)
-                manager.requestPinAppWidget(provider, null, QrCodeWidgetReceiver.pinSuccessCallback(context))
-            } else {
-                val provider = ComponentName(context, QrWidgetReceiver::class.java)
-                manager.requestPinAppWidget(provider, null, QrWidgetReceiver.pinSuccessCallback(context))
-            }
+            val receiverClass = if (useQrCodeWidget) QrCodeWidgetReceiver::class.java else QrWidgetReceiver::class.java
+            val callback = if (useQrCodeWidget) QrCodeWidgetReceiver.pinSuccessCallback(context) else QrWidgetReceiver.pinSuccessCallback(context)
+            manager.requestPinAppWidget(ComponentName(context, receiverClass), null, callback)
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
+++ b/app/src/main/java/com/hereliesaz/qard/ui/ConfigActivity.kt
@@ -111,6 +111,7 @@ import com.hereliesaz.qard.ads.PresetsAdBanner
 import com.hereliesaz.qard.ads.rememberInterstitialController
 import com.hereliesaz.qard.ui.theme.LogoPink
 import com.hereliesaz.qard.ui.theme.QaRdTheme
+import com.hereliesaz.qard.widget.QrCodeWidgetReceiver
 import com.hereliesaz.qard.widget.QrGenerator
 import com.hereliesaz.qard.widget.QrImageExporter
 import com.hereliesaz.qard.widget.QrWidget
@@ -298,6 +299,7 @@ fun ConfigScreen(
     var showGradientColorPicker2 by remember { mutableStateOf(false) }
     var showFgGradientColorPicker1 by remember { mutableStateOf(false) }
     var showFgGradientColorPicker2 by remember { mutableStateOf(false) }
+    var showWidgetTypeDialog by remember { mutableStateOf(false) }
 
     var presets by remember { mutableStateOf<List<QrConfig>>(emptyList()) }
 
@@ -393,11 +395,9 @@ fun ConfigScreen(
         }
     }
 
-    // Pin a brand-new widget to the home screen — the same flow as the launcher's
-    // widget picker "Add" button. The launcher drops the widget in an open spot
-    // with its resize bounding box; the new widget's id arrives in the pin-success
-    // broadcast handled by QrWidgetReceiver.
-    fun pinCurrentAsWidget() {
+    // Pin a brand-new widget to the home screen. useQrCodeWidget selects the compact
+    // 1×1 QR Code widget; false (default) uses the generic 2×2 QaRd widget.
+    fun pinCurrentAsWidget(useQrCodeWidget: Boolean = false) {
         val cfg = config ?: return
         val manager = AppWidgetManager.getInstance(context)
         if (!manager.isRequestPinAppWidgetSupported) {
@@ -411,8 +411,13 @@ fun ConfigScreen(
         scope.launch {
             persistCurrentConfig()
             dataStore.savePendingPinConfig(cfg)
-            val provider = ComponentName(context, QrWidgetReceiver::class.java)
-            manager.requestPinAppWidget(provider, null, QrWidgetReceiver.pinSuccessCallback(context))
+            if (useQrCodeWidget) {
+                val provider = ComponentName(context, QrCodeWidgetReceiver::class.java)
+                manager.requestPinAppWidget(provider, null, QrCodeWidgetReceiver.pinSuccessCallback(context))
+            } else {
+                val provider = ComponentName(context, QrWidgetReceiver::class.java)
+                manager.requestPinAppWidget(provider, null, QrWidgetReceiver.pinSuccessCallback(context))
+            }
         }
     }
 
@@ -545,7 +550,7 @@ fun ConfigScreen(
                         hasData = hasData,
                         isStandalone = isStandalone,
                         onSaveImage = onSaveImageClick,
-                        onCreateWidget = { if (isStandalone) pinCurrentAsWidget() else finalizeWidget() }
+                        onCreateWidget = { if (isStandalone) showWidgetTypeDialog = true else finalizeWidget() }
                     )
                 }
                     }
@@ -553,6 +558,42 @@ fun ConfigScreen(
                 AdBanner()
             }
         }
+    }
+
+    if (showWidgetTypeDialog) {
+        AlertDialog(
+            onDismissRequest = { showWidgetTypeDialog = false },
+            title = { Text("Add to Home Screen") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Choose a widget type:", style = MaterialTheme.typography.bodyMedium)
+                    Button(
+                        onClick = {
+                            showWidgetTypeDialog = false
+                            pinCurrentAsWidget(false)
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("QaRd (2×2)")
+                    }
+                    OutlinedButton(
+                        onClick = {
+                            showWidgetTypeDialog = false
+                            pinCurrentAsWidget(true)
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("QR Code (1×1)")
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showWidgetTypeDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 
     if (showForegroundColorPicker) {

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrCodeWidgetReceiver.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrCodeWidgetReceiver.kt
@@ -6,6 +6,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.updateAll
@@ -43,6 +44,8 @@ class QrCodeWidgetReceiver : GlanceAppWidgetReceiver() {
                 val saved = store.getSavedConfigs().first()
                 store.saveConfigs((saved + config).distinct())
                 QrWidget().updateAll(context)
+            } catch (e: Exception) {
+                Log.e("QrCodeWidgetReceiver", "Failed to handle pin success for widget $appWidgetId", e)
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrCodeWidgetReceiver.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrCodeWidgetReceiver.kt
@@ -1,0 +1,68 @@
+package com.hereliesaz.qard.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.updateAll
+import com.hereliesaz.qard.data.QrDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class QrCodeWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = QrWidget()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_PIN_SUCCESS) {
+            handlePinSuccess(context, intent)
+            return
+        }
+        super.onReceive(context, intent)
+    }
+
+    private fun handlePinSuccess(context: Context, intent: Intent) {
+        val appWidgetId = intent.getIntExtra(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        )
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return
+
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
+                val store = QrDataStore(context)
+                val config = store.takePendingPinConfig() ?: return@launch
+                store.saveConfig(appWidgetId, config)
+                val saved = store.getSavedConfigs().first()
+                store.saveConfigs((saved + config).distinct())
+                QrWidget().updateAll(context)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val ACTION_PIN_SUCCESS = "com.hereliesaz.qard.action.PIN_QR_CODE_WIDGET_SUCCESS"
+
+        fun pinSuccessCallback(context: Context): PendingIntent {
+            val intent = Intent(context, QrCodeWidgetReceiver::class.java).apply {
+                action = ACTION_PIN_SUCCESS
+                component = ComponentName(context, QrCodeWidgetReceiver::class.java)
+            }
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            return PendingIntent.getBroadcast(context, 1, intent, flags)
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/qard/widget/QrWidgetReceiver.kt
+++ b/app/src/main/java/com/hereliesaz/qard/widget/QrWidgetReceiver.kt
@@ -6,6 +6,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.updateAll
@@ -50,6 +51,8 @@ class QrWidgetReceiver : GlanceAppWidgetReceiver() {
                 val saved = store.getSavedConfigs().first()
                 store.saveConfigs((saved + config).distinct())
                 QrWidget().updateAll(context)
+            } catch (e: Exception) {
+                Log.e("QrWidgetReceiver", "Failed to handle pin success for widget $appWidgetId", e)
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">QaRd</string>
     <string name="appwidget_description">A widget that displays a user-defined QR code.</string>
+    <string name="qr_code_widget_description">A compact QR code widget for your home screen.</string>
     <string name="configure_widget_title">Configure QR Code</string>
     <string name="qr_code_data_label">QR Code Data</string>
     <string name="save_widget_button">Create Widget</string>

--- a/app/src/main/res/xml/qr_code_widget_info.xml
+++ b/app/src/main/res/xml/qr_code_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/qr_code_widget_description"
+    android:initialLayout="@layout/widget_qr"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
+    android:targetCellWidth="1"
+    android:targetCellHeight="1"
+    android:maxResizeWidth="1200dp"
+    android:maxResizeHeight="1200dp"
+    android:previewImage="@mipmap/ic_launcher"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="86400000"
+    android:widgetCategory="home_screen|keyguard" />


### PR DESCRIPTION
## Summary

- Registers a second `AppWidgetProvider` (`QrCodeWidgetReceiver`) with a 1×1 default cell size, so the launcher's widget picker shows two QaRd entries: the existing **QaRd (2×2)** and a new **QR Code (1×1)**
- Both widgets use the same `QrWidget` rendering pipeline and `QrDataStore` persistence — the only difference is the registered class/XML metadata
- When the user taps **Create widget** on the Save screen, a dialog now lets them choose between the two sizes before the pin request is sent to the launcher

## Files changed

| File | Change |
|------|--------|
| `widget/QrCodeWidgetReceiver.kt` | New receiver for the 1×1 widget, mirrors `QrWidgetReceiver` with its own pin-success action |
| `res/xml/qr_code_widget_info.xml` | Widget metadata: 1×1 target cells, same resize/category flags as the existing 2×2 |
| `AndroidManifest.xml` | Registers the new receiver |
| `res/values/strings.xml` | Adds `qr_code_widget_description` string |
| `ui/ConfigActivity.kt` | `pinCurrentAsWidget(useQrCodeWidget: Boolean)` now accepts a flag; "Create widget" shows a two-option dialog in standalone mode |

## Test plan

- [ ] Long-press home screen → Widgets → confirm two QaRd entries appear: "QaRd" and "QR Code"
- [ ] Add each from the picker; verify both render and tap to open `WidgetMenuActivity`
- [ ] In the app, create a QR code → Save → "Create widget" → confirm the dialog appears with both options
- [ ] Pick each option; verify the correct widget size is placed on the home screen with the pre-configured QR code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfcEyqdU2Z4qHQ7fev6J31

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfcEyqdU2Z4qHQ7fev6J31)_